### PR TITLE
Fix/add operator id to path

### DIFF
--- a/platiagro/metrics.py
+++ b/platiagro/metrics.py
@@ -29,6 +29,10 @@ def list_metrics(experiment_id: Optional[str] = None,
 
     Returns:
         list: A list of metrics.
+
+    Raises:
+        TypeError: when experiment_id is undefined in args and env.
+        TypeError: when operator_id is undefined in args and env.
     """
     if experiment_id is None:
         experiment_id = get_experiment_id()
@@ -59,6 +63,10 @@ def save_metrics(reset: bool = False,
         experiment_id (str, optional): the experiment uuid. Defaults to None
         operator_id (str, optional): the operator uuid. Defaults to None
         **kwargs: the metrics dict.
+
+    Raises:
+        TypeError: when experiment_id is undefined in args and env.
+        TypeError: when operator_id is undefined in args and env.
     """
     if experiment_id is None:
         experiment_id = get_experiment_id()

--- a/platiagro/metrics.py
+++ b/platiagro/metrics.py
@@ -13,16 +13,19 @@ from .figures import save_figure
 from .util import BUCKET_NAME, MINIO_CLIENT, get_experiment_id, \
     get_operator_id, make_bucket
 
-PREFIX = "experiments"
+PREFIX_1 = "experiments"
+PREFIX_2 = "operators"
 METRICS_FILE = "metrics.json"
 CONFUSION_MATRIX = "confusion_matrix"
 
 
-def list_metrics(experiment_id: Optional[str] = None) -> List[Dict[str, object]]:
-    """Lists all metrics of an experiment.
+def list_metrics(experiment_id: Optional[str] = None,
+                 operator_id: Optional[str] = None) -> List[Dict[str, object]]:
+    """Lists metrics from object storage.
 
     Args:
         experiment_id (str, optional): the experiment uuid. Defaults to None.
+        operator_id (str, optional): the operator uuid. Defaults to None.
 
     Returns:
         list: A list of metrics.
@@ -30,8 +33,11 @@ def list_metrics(experiment_id: Optional[str] = None) -> List[Dict[str, object]]
     if experiment_id is None:
         experiment_id = get_experiment_id()
 
+    if operator_id is None:
+        operator_id = get_operator_id()
+
     try:
-        object_name = f'{PREFIX}/{experiment_id}/{METRICS_FILE}'
+        object_name = f"{PREFIX_1}/{experiment_id}/{PREFIX_2}/{operator_id}/{METRICS_FILE}"
         data = MINIO_CLIENT.get_object(
             bucket_name=BUCKET_NAME,
             object_name=object_name,
@@ -57,7 +63,10 @@ def save_metrics(reset: bool = False,
     if experiment_id is None:
         experiment_id = get_experiment_id()
 
-    object_name = f'{PREFIX}/{experiment_id}/{METRICS_FILE}'
+    if operator_id is None:
+        operator_id = get_operator_id()
+
+    object_name = f"{PREFIX_1}/{experiment_id}/{PREFIX_2}/{operator_id}/{METRICS_FILE}"
 
     # ensures MinIO bucket exists
     make_bucket(BUCKET_NAME)

--- a/platiagro/models.py
+++ b/platiagro/models.py
@@ -6,32 +6,43 @@ from typing import Dict, Optional
 from joblib import dump, load
 from minio.error import NoSuchBucket, NoSuchKey
 
-from .util import BUCKET_NAME, MINIO_CLIENT, get_experiment_id, make_bucket
+from .util import BUCKET_NAME, MINIO_CLIENT, get_experiment_id, \
+    get_operator_id, make_bucket
 
-PREFIX = "experiments"
+PREFIX_1 = "experiments"
+PREFIX_2 = "operators"
 MODEL_FILE = "model.joblib"
 
 
-def load_model(experiment_id: Optional[str] = None) -> Dict[str, object]:
-    """Retrieves a model.
+def load_model(experiment_id: Optional[str] = None,
+               operator_id: Optional[str] = None) -> Dict[str, object]:
+    """Retrieves a model from object storage.
 
     Args:
         experiment_id (str, optional): the experiment uuid. Defaults to None.
+        operator_id (str, optional): the operator uuid. Defaults to None.
 
     Returns:
         dict: A dictionary of models.
+
+    Raises:
+        TypeError: when experiment_id is undefined in args and env.
+        TypeError: when operator_id is undefined in args and env.
     """
     if experiment_id is None:
         experiment_id = get_experiment_id()
 
+    if operator_id is None:
+        operator_id = get_operator_id()
+
     try:
-        object_name = f'{PREFIX}/{experiment_id}/{MODEL_FILE}'
+        object_name = f"{PREFIX_1}/{experiment_id}/{PREFIX_2}/{operator_id}/{MODEL_FILE}"
         data = MINIO_CLIENT.get_object(
             bucket_name=BUCKET_NAME,
             object_name=object_name,
         )
     except (NoSuchBucket, NoSuchKey):
-        raise FileNotFoundError(f"No such file or directory: '{experiment_id}'")
+        return {}
 
     buffer = BytesIO(data.read())
 
@@ -42,14 +53,20 @@ def save_model(**kwargs):
     """Serializes and saves models.
 
     Args:
-        experiment_id (str, optional): the experiment uuid. Defaults to None.
         **kwargs: the models as keyword arguments.
+
+    Raises:
+        TypeError: when a figure is not a matplotlib figure.
     """
     experiment_id = kwargs.get("experiment_id")
     if experiment_id is None:
         experiment_id = get_experiment_id()
 
-    object_name = f'{PREFIX}/{experiment_id}/{MODEL_FILE}'
+    operator_id = kwargs.get("operator_id")
+    if operator_id is None:
+        operator_id = get_operator_id()
+
+    object_name = f"{PREFIX_1}/{experiment_id}/{PREFIX_2}/{operator_id}/{MODEL_FILE}"
 
     model_buffer = BytesIO()
     dump(kwargs, model_buffer)

--- a/platiagro/models.py
+++ b/platiagro/models.py
@@ -57,6 +57,10 @@ def save_model(**kwargs):
 
     Raises:
         TypeError: when a figure is not a matplotlib figure.
+
+    Raises:
+        TypeError: when experiment_id is undefined in args and env.
+        TypeError: when operator_id is undefined in args and env.
     """
     experiment_id = kwargs.get("experiment_id")
     if experiment_id is None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,12 +3,16 @@ from io import BytesIO
 from json import dumps
 from os import environ
 from unittest import TestCase
+from uuid import uuid4
 
 import numpy as np
 import pandas as pd
 from minio.error import BucketAlreadyOwnedByYou
 from platiagro import list_metrics, save_metrics
 from platiagro.util import BUCKET_NAME, MINIO_CLIENT
+
+EXPERIMENT_ID = str(uuid4())
+OPERATOR_ID = str(uuid4())
 
 
 class TestMetrics(TestCase):
@@ -29,25 +33,27 @@ class TestMetrics(TestCase):
         buffer = BytesIO(dumps(metric).encode())
         MINIO_CLIENT.put_object(
             bucket_name=BUCKET_NAME,
-            object_name="experiments/mock/metrics.json",
+            object_name=f"experiments/{EXPERIMENT_ID}/operators/{OPERATOR_ID}/metrics.json",
             data=buffer,
             length=buffer.getbuffer().nbytes,
         )
 
     def test_load_metrics(self):
-        with self.assertRaises(FileNotFoundError):
-            list_metrics("UNK")
-
         with self.assertRaises(TypeError):
             list_metrics()
 
-        environ["EXPERIMENT_ID"] = "mock"
+        with self.assertRaises(FileNotFoundError):
+            list_metrics("UNK", "UNK")
+
+        environ["EXPERIMENT_ID"] = EXPERIMENT_ID
+        environ["OPERATOR_ID"] = OPERATOR_ID
         metrics = list_metrics()
         self.assertIsInstance(metrics, list)
         self.assertDictEqual(metrics[0], {"accuracy": 1.0})
         del environ["EXPERIMENT_ID"]
+        del environ["OPERATOR_ID"]
 
-        metrics = list_metrics("mock")
+        metrics = list_metrics(experiment_id=EXPERIMENT_ID, operator_id=OPERATOR_ID)
         self.assertIsInstance(metrics, list)
         self.assertDictEqual(metrics[0], {"accuracy": 1.0})
 
@@ -64,13 +70,14 @@ class TestMetrics(TestCase):
         scores = pd.Series([1.0, 0.5, 0.1])
 
         environ["EXPERIMENT_ID"] = "test"
+        environ["OPERATOR_ID"] = "test"
         save_metrics(accuracy=1.0)
         save_metrics(scores=scores)
         save_metrics(reset=True,
                      r2_score=-3.0)
-        environ["OPERATOR_ID"] = "test"
         save_metrics(confusion_matrix=confusion_matrix)
         del environ["EXPERIMENT_ID"]
+        del environ["OPERATOR_ID"]
 
         with self.assertRaises(TypeError):
             save_metrics(experiment_id="test",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,12 +2,16 @@
 from io import BytesIO
 from os import SEEK_SET, environ
 from unittest import TestCase
+from uuid import uuid4
 
 from joblib import dump
 from minio.error import BucketAlreadyOwnedByYou
 
 from platiagro import load_model, save_model
 from platiagro.util import BUCKET_NAME, MINIO_CLIENT
+
+EXPERIMENT_ID = str(uuid4())
+OPERATOR_ID = str(uuid4())
 
 
 class MockModel:
@@ -35,25 +39,24 @@ class TestModels(TestCase):
         buffer.seek(0, SEEK_SET)
         MINIO_CLIENT.put_object(
             bucket_name=BUCKET_NAME,
-            object_name="experiments/mock/model.joblib",
+            object_name=f"experiments/{EXPERIMENT_ID}/operators/{OPERATOR_ID}/model.joblib",
             data=buffer,
             length=buffer.getbuffer().nbytes,
         )
 
     def test_load_model(self):
-        with self.assertRaises(FileNotFoundError):
-            load_model("UNK")
-
         with self.assertRaises(TypeError):
             load_model()
 
-        environ["EXPERIMENT_ID"] = "mock"
+        environ["EXPERIMENT_ID"] = EXPERIMENT_ID
+        environ["OPERATOR_ID"] = OPERATOR_ID
         model = load_model()
         self.assertIsInstance(model, dict)
         self.assertIsInstance(model["model"], MockModel)
         del environ["EXPERIMENT_ID"]
+        del environ["OPERATOR_ID"]
 
-        model = load_model("mock")
+        model = load_model(experiment_id=EXPERIMENT_ID, operator_id=OPERATOR_ID)
         self.assertIsInstance(model, dict)
         self.assertIsInstance(model["model"], MockModel)
 
@@ -63,14 +66,18 @@ class TestModels(TestCase):
             save_model(model)
 
         environ["EXPERIMENT_ID"] = "test"
+        environ["OPERATOR_ID"] = "test"
         model = MockModel()
         save_model()
         del environ["EXPERIMENT_ID"]
+        del environ["OPERATOR_ID"]
 
         model = MockModel()
         save_model(experiment_id="test",
+                   operator_id="test",
                    model=model)
 
         model = MockModel()
         save_model(experiment_id="test",
+                   operator_id="test",
                    model=model)


### PR DESCRIPTION
Concatenates operator_id to model path

Bug fix: subsequent components overwrite a model saved previously.
Updates unit tests.

Concatenates operator_id to metrics path

Bug fix: subsequent components overwrite a metric saved previously.
Updates unit tests.

Adds docstrings

Adds missing section: 'Raises'.