### PR TITLE
Fix/dtype load dataset

### DIFF
--- a/platiagro/deployment.py
+++ b/platiagro/deployment.py
@@ -2,7 +2,6 @@
 """A module for testing components before deployment."""
 from os import environ, kill
 from random import randint
-from sys import stderr
 from subprocess import PIPE, Popen
 from typing import Optional
 
@@ -13,9 +12,11 @@ from seldon_core.microservice_tester import run_method
 
 from .util import get_experiment_id, get_operator_id
 
+
 class Bunch(object):
     def __init__(self, adict):
         self.__dict__.update(adict)
+
 
 def test_deployment(contract: str,
                     module: str = "Model",

--- a/platiagro/featuretypes.py
+++ b/platiagro/featuretypes.py
@@ -45,7 +45,6 @@ def is_number(series: pd.Series):
     for _, value in series.iteritems():
         try:
             float(value)
-            break
         except ValueError:
             return False
     return True


### PR DESCRIPTION
Fix flake8 code smells
Sets pandas.DataFrame dtype depending on featuretype
'DateTime' and 'Categorical' columns are set as object

This is helpful for sklearn OrdinalEncoder.