### PR TITLE
Fix OverflowError in datetime.parse

### DIFF
--- a/platiagro/featuretypes.py
+++ b/platiagro/featuretypes.py
@@ -63,7 +63,7 @@ def is_datetime(series: pd.Series):
         try:
             parse(str(value))
             break
-        except ValueError:
+        except (ValueError, OverflowError) as e:
             return False
     return True
 

--- a/platiagro/featuretypes.py
+++ b/platiagro/featuretypes.py
@@ -63,7 +63,7 @@ def is_datetime(series: pd.Series):
         try:
             parse(str(value))
             break
-        except (ValueError, OverflowError) as e:
+        except (ValueError, OverflowError):
             return False
     return True
 

--- a/tests/test_featuretypes.py
+++ b/tests/test_featuretypes.py
@@ -17,7 +17,7 @@ class TestFeaturetypes(TestCase):
 
         df = pd.DataFrame({
             "col0": ["01-01-2019", "01-01-2020", "01-01-2021"],
-            "col1": ["Iris-setosa", "Iris-setosa", "Iris-setosa"],
+            "col1": ["Iris-setosa", "Iris-setosa", "Jun 999999999999999"],
             "col2": [5.1, float('nan'), 4.7],
             "col3": ["22.4", "10", "4.7"],
         })


### PR DESCRIPTION
Dates that wouldn't fit in a signed integer throws OverflowError:
Jun 999999999999999