### PR TITLE
Replaces relative imports by absolute imports

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -60,6 +60,8 @@ jobs:
           - Usar Google Style Python Docstring: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
           - Verificar se código-fonte e `docs/source/platiagro.rst` estão "compatíveis".
           - TODOS OS MÉTODOS EM `platiagro/__init__.py` **DEVEM ESTAR ATUALIZADOS NOS DOCS**.
+          - Usar sempre import absoluto.
+            ex: `from platiagro.featuretypes import CATEGORICAL` (BOM), `from .featuretypes import CATEGORICAL` (RUIM)
     - uses: actions/checkout@v2
     - name: Set up Python 3.6
       uses: actions/setup-python@v1

--- a/platiagro/__init__.py
+++ b/platiagro/__init__.py
@@ -1,10 +1,10 @@
-from .datasets import list_datasets, load_dataset, save_dataset, \
+from platiagro.datasets import list_datasets, load_dataset, save_dataset, \
     stat_dataset, download_dataset, update_dataset_metadata
-from .featuretypes import infer_featuretypes, validate_featuretypes, \
+from platiagro.featuretypes import infer_featuretypes, validate_featuretypes, \
     DATETIME, CATEGORICAL, NUMERICAL
-from .figures import list_figures, save_figure
-from .metrics import list_metrics, save_metrics
-from .models import load_model, save_model
+from platiagro.figures import list_figures, save_figure
+from platiagro.metrics import list_metrics, save_metrics
+from platiagro.models import load_model, save_model
 
 __all__ = ["list_datasets", "load_dataset", "save_dataset", "stat_dataset",
            "download_dataset", "update_dataset_metadata",

--- a/platiagro/datasets.py
+++ b/platiagro/datasets.py
@@ -9,8 +9,9 @@ import pandas as pd
 from numpy import delete
 from minio.error import NoSuchBucket, NoSuchKey
 
-from .featuretypes import CATEGORICAL, DATETIME, infer_featuretypes
-from .util import BUCKET_NAME, MINIO_CLIENT, S3FS, make_bucket, get_operator_id, get_run_id, metadata_exists
+from platiagro.featuretypes import CATEGORICAL, DATETIME, infer_featuretypes
+from platiagro.util import BUCKET_NAME, MINIO_CLIENT, S3FS, make_bucket, \
+    get_operator_id, get_run_id, metadata_exists
 
 PREFIX = "datasets"
 

--- a/platiagro/deployment.py
+++ b/platiagro/deployment.py
@@ -10,7 +10,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from seldon_core.microservice_tester import run_method
 
-from .util import get_experiment_id, get_operator_id
+from platiagro.util import get_experiment_id, get_operator_id
 
 
 class Bunch(object):

--- a/platiagro/figures.py
+++ b/platiagro/figures.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import base64
 import matplotlib.figure
 
-from .util import BUCKET_NAME, MINIO_CLIENT, make_bucket, \
+from platiagro.util import BUCKET_NAME, MINIO_CLIENT, make_bucket, \
     get_experiment_id, get_operator_id, get_run_id, stat_metadata, operator_filepath
 
 

--- a/platiagro/metrics.py
+++ b/platiagro/metrics.py
@@ -9,8 +9,8 @@ import pandas as pd
 import seaborn as sns
 from minio.error import NoSuchBucket, NoSuchKey
 
-from .figures import save_figure
-from .util import BUCKET_NAME, MINIO_CLIENT, get_experiment_id, \
+from platiagro.figures import save_figure
+from platiagro.util import BUCKET_NAME, MINIO_CLIENT, get_experiment_id, \
     get_operator_id, make_bucket, get_run_id, stat_metadata, operator_filepath
 
 METRICS_FILE = "metrics.json"

--- a/platiagro/models.py
+++ b/platiagro/models.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 from joblib import dump, load
 from minio.error import NoSuchBucket, NoSuchKey
 
-from .util import BUCKET_NAME, MINIO_CLIENT, get_experiment_id, \
+from platiagro.util import BUCKET_NAME, MINIO_CLIENT, get_experiment_id, \
     get_operator_id, make_bucket
 
 PREFIX_1 = "experiments"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -106,7 +106,7 @@ class TestMetrics(TestCase):
                                operator_id=OPERATOR_ID,
                                run_id="latest")
         self.assertTrue(isinstance(metrics, list))
-        self.assertEquals(metrics, [])
+        self.assertEqual(metrics, [])
 
         environ["EXPERIMENT_ID"] = EXPERIMENT_ID
         environ["OPERATOR_ID"] = OPERATOR_ID


### PR DESCRIPTION
This was changed because PEP 8 encourages absolute imports:
See https://www.python.org/dev/peps/pep-0008/ for further details.

Also added a instruction to use absolute imports in code-review tips.