### PR TITLE
Handle Empty Metadata Properties

### DIFF
--- a/platiagro/datasets.py
+++ b/platiagro/datasets.py
@@ -99,6 +99,10 @@ def load_dataset(name: str,
             object_name=path.lstrip(f"{BUCKET_NAME}/"),
         )
         return BytesIO(data.read())
+    except KeyError:
+        # metadata file does not contains "columns" or "featuretypes"
+        # ignore this error and return dataset without cast its type
+        pass
     except FileNotFoundError:
         raise FileNotFoundError("The specified dataset does not exist")
 


### PR DESCRIPTION
- when executing `save_dataset` from an `io.BufferedReader` content other than `pd.DataFrame`, the properties "featuretypes" and "columns" are not being set, thus causing `KeyError` when executing `load_dataset`, as it will try to cast dtype when returning the dataset