### PR TITLE
Fix/refactor unit tests

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -77,16 +77,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Run MinIO image
-      run: |
-        docker run -d -p 9000:9000 \
-        -e "MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY" \
-        -e "MINIO_SECRET_KEY=$MINIO_SECRET_KEY" \
-        minio/minio:RELEASE.2018-02-09T22-40-05Z server /data
-      env:
-        MINIO_ACCESS_KEY: minio
-        MINIO_SECRET_KEY: minio123
-
     - name: Install dependencies
       run: |
         python -m pip install wheel
@@ -98,10 +88,6 @@ jobs:
         coverage erase
         coverage run --branch --source=platiagro -m pytest
         coverage xml -i
-      env:
-        MINIO_ENDPOINT: localhost:9000
-        MINIO_ACCESS_KEY: minio
-        MINIO_SECRET_KEY: minio123
 
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -19,58 +19,19 @@ jobs:
         python-version: [ "3.8" ]
 
     steps:
-    - name: Code review tips
-      uses: unsplash/comment-on-pr@master
-      if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        msg: |
-          ## Dicas para revisão de código
-
-          ### Commits
-          - Título (1a linha do commit): apresentar resumo do que foi alterado/adicionado/removido.
-            ex: adiciona action que salva parametros no backend; exibe rótulo no componente de selecao de dataset;
-          - Descrição (outras linhas): dar mais detalhes de cada alteração:
-            - motivos das alterações
-              ex: havia um bug que causava...; nova funcionalidade que faz isso...; código foi movido para...;
-            - bibliotecas adicionadas e versões (requirements.txt)
-              ex: atualiza para minio 6.0.0;
-            - testes unitários criados/alterados
-              ex: adiciona testes para o método stat_dataset;
-            - alterações do `docs/source/platiagro.rst`
-              ex: adiciona documentação para save_metrics
-          - Mensagens auto-explicativas! Quem revisa o código deve entender o que foi feito (e porque foi feito) **sem perguntar para quem fez o commit**.
-          - Não devem ter conflitos. Solicitar que sejam resolvidas as ocorrências de "This branch has conflicts that must be resolved".
-
-          ### SonarCloud Quality Gate
-          - Coverage > 80.0%, e sempre que possível = 100%
-          - 0 Bugs, 0 Code Smells, 0 Vulnerabilities
-          - São permitidos os seguintes Security Hotspots:
-            - Make sure this permissive CORS policy is safe here.
-            - Make sure publicly writable directories are used safely here.
-            - Using http protocol is insecure. Use https instead.
-            - Make sure disabling CSRF protection is safe here.
-
-          ### Build Github actions COM SUCESSO
-
-          ### Python
-          - Usar Python 3.8
-          - Remover `print`.
-          - Não deixar código-fonte comentado.
-          - f-string `f'text-{variable}'` é melhor que `'text-{}'.format(variable)` e `'text-' + variable`
-          - Métodos que são chamados de outros arquivos `.py` **DEVEM TER Docstring**.
-          - Usar Google Style Python Docstring: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
-          - Verificar se código-fonte e `docs/source/platiagro.rst` estão "compatíveis".
-          - TODOS OS MÉTODOS EM `platiagro/__init__.py` **DEVEM ESTAR ATUALIZADOS NOS DOCS**.
-          - Usar sempre import absoluto.
-            ex: `from platiagro.featuretypes import CATEGORICAL` (BOM), `from .featuretypes import CATEGORICAL` (RUIM)
-
     - name: Checkout 🛎️
       uses: actions/checkout@v2
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
+
+    - name: Code review tips
+      uses: machine-learning-apps/pr-comment@master
+      if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        path: CODE-REVIEW.md
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/CODE-REVIEW.md
+++ b/CODE-REVIEW.md
@@ -1,0 +1,88 @@
+## Dicas para revisão de código
+
+### Commits
+- Título (1a linha do commit): apresentar resumo do que foi alterado/adicionado/removido.
+ex: adiciona action que salva parametros no backend; exibe rótulo no componente de selecao de dataset;
+- Descrição (outras linhas): dar mais detalhes de cada alteração:
+- motivos das alterações
+    ex: havia um bug que causava...; nova funcionalidade que faz isso...; código foi movido para...;
+- bibliotecas adicionadas e versões (requirements.txt)
+    ex: atualiza para minio 6.0.0;
+- testes unitários criados/alterados
+    ex: adiciona testes para o método stat_dataset;
+- alterações do `docs/source/platiagro.rst`
+    ex: adiciona documentação para save_metrics
+- Mensagens auto-explicativas! Quem revisa o código deve entender o que foi feito (e porque foi feito) **sem perguntar para quem fez o commit**.
+- Não devem ter conflitos. Solicitar que sejam resolvidas as ocorrências de "This branch has conflicts that must be resolved".
+
+### SonarCloud Quality Gate
+- Coverage > 80.0%, e sempre que possível = 100%
+- 0 Bugs, 0 Code Smells, 0 Vulnerabilities
+
+### Build Github actions COM SUCESSO
+
+### Python
+- Usar Python 3.8
+- Remover `print`.
+- Não deixar código-fonte comentado.
+- f-string `f'text-{variable}'` é melhor que `'text-{}'.format(variable)` e `'text-' + variable`
+- Métodos que são chamados de outros arquivos `.py` **DEVEM TER Docstring**.
+- Usar Google Style Python Docstring: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
+- Verificar se código-fonte e `docs/source/platiagro.rst` estão "compatíveis".
+- TODOS OS MÉTODOS EM `platiagro/__init__.py` **DEVEM ESTAR ATUALIZADOS NOS DOCS**.
+- Usar sempre import absoluto.
+ex: `from platiagro.featuretypes import CATEGORICAL` (BOM), `from .featuretypes import CATEGORICAL` (RUIM)
+
+## Testes Unitários
+- Todo teste deve ter um docstring descrevendo o que é testado:
+```python
+def test_something_exception(self):
+    """ 
+    Should raise an exception when ...
+    """
+```
+- Cada função deve preferencialmente testar 1 única chamada:
+```python
+ def test_something_success(self): 
+    """ 
+    Should return ok.
+    """
+    result = something()
+    assert result == "ok"
+
+def test_something_exception(self):
+    """ 
+    Should raise an exception.
+    """
+    with self.assertRaises(Exception):
+        something()
+```
+- Utilize [tests/util.py](./tests/util.py) para códigos de teste reutilizáveis.
+```python
+import tests.util as util
+
+@mock.patch.object(
+    MINIO_CLIENT,
+    "get_object",
+    side_effect=util.NO_SUCH_KEY_ERROR,
+)
+```
+- Quando criar um mock de uma função, use o [`assert_any_call`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.assert_any_call) ou [`assert_called_with`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.assert_called_with) para testar se a função recebeu os parâmetros adequados.<br>
+Caso algum dos parâmetros tenha valor dinâmico, ou possa ser ignorado, utilize [`mock.ANY`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.ANY).
+```python
+@mock.patch.object( 
+    MINIO_CLIENT, 
+    "put_object", 
+    side_effect=util.put_object_side_effect, 
+) 
+def test_update_dataset_metadata( 
+    self, mock_put_object
+):
+    ...
+    mock_put_object.assert_any_call( 
+        bucket_name=BUCKET_NAME, 
+        object_name=f"datasets/{dataset_name}/{dataset_name}.metadata", 
+        data=mock.ANY, 
+        length=mock.ANY, 
+    ) 
+```

--- a/platiagro/datasets.py
+++ b/platiagro/datasets.py
@@ -67,6 +67,8 @@ def load_dataset(
     Raises:
         FileNotFoundError: If dataset does not exist in the object storage.
     """
+    make_bucket(BUCKET_NAME)
+
     if run_id is None:
         # gets run_id from env variable
         # Attention: returns None if env is unset
@@ -154,6 +156,7 @@ def get_dataset(
     Raises:
         FileNotFoundError: If dataset does not exist in the object storage.
     """
+    make_bucket(BUCKET_NAME)
 
     # this function serves to cover None and 'latest' cases
     run_id = handle_run_id(name, run_id)
@@ -364,6 +367,8 @@ def stat_dataset(
     Raises:
         FileNotFoundError: If dataset does not exist in the object storage.
     """
+    make_bucket(BUCKET_NAME)
+
     metadata = {}
 
     # remove /tmp/data/ from dataset name
@@ -444,6 +449,8 @@ def update_dataset_metadata(
         run_id (str, optional): the run id of trainning pipeline. Defaults to None.
         operator_id (str, optional): the operator uuid. Defaults to None.
     """
+    make_bucket(BUCKET_NAME)
+
     object_name = _metadata_filepath(name, run_id, operator_id)
 
     # encodes metadata to JSON format

--- a/platiagro/datasets.py
+++ b/platiagro/datasets.py
@@ -9,8 +9,15 @@ import pandas as pd
 from minio.error import S3Error
 
 from platiagro.featuretypes import CATEGORICAL, DATETIME, infer_featuretypes
-from platiagro.util import (BUCKET_NAME, MINIO_CLIENT, S3FS, get_operator_id,
-                            get_run_id, make_bucket, metadata_exists)
+from platiagro.util import (
+    BUCKET_NAME,
+    MINIO_CLIENT,
+    S3FS,
+    get_operator_id,
+    get_run_id,
+    make_bucket,
+    metadata_exists,
+)
 
 PREFIX = "datasets"
 
@@ -29,17 +36,19 @@ def list_datasets() -> List[str]:
     objects = MINIO_CLIENT.list_objects(BUCKET_NAME, PREFIX + "/")
 
     for obj in objects:
-        name = obj.object_name[len(PREFIX) + 1:-1]
+        name = obj.object_name[len(PREFIX) + 1 : -1]
         datasets.append(name)
 
     return datasets
 
 
-def load_dataset(name: str,
-                 run_id: Optional[str] = None,
-                 operator_id: Optional[str] = None,
-                 page: Optional[int] = None,
-                 page_size: Optional[int] = None) -> Union[pd.DataFrame, BinaryIO]:
+def load_dataset(
+    name: str,
+    run_id: Optional[str] = None,
+    operator_id: Optional[str] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+) -> Union[pd.DataFrame, BinaryIO]:
     """Retrieves the contents of a dataset.
 
     If run_id exists, then loads the dataset from the specified run.
@@ -95,11 +104,15 @@ def load_dataset(name: str,
 
     try:
         metadata = stat_dataset(name, run_id, operator_id)
-        dataset = pd.read_csv(S3FS.open(path), header=0, index_col=False, nrows=nrows, skiprows=skiprows)
+        dataset = pd.read_csv(
+            S3FS.open(path), header=0, index_col=False, nrows=nrows, skiprows=skiprows
+        )
 
         dtypes = dict(
             (column, "object")
-            for column, ftype in zip(metadata["columns"], metadata["featuretypes"])
+            for column, ftype in zip(
+                metadata.get("columns", []), metadata.get("featuretypes", [])
+            )
             if ftype in [CATEGORICAL, DATETIME]
         )
         dataset = dataset.astype(dtypes)
@@ -120,9 +133,9 @@ def load_dataset(name: str,
     return dataset
 
 
-def get_dataset(name: str,
-                run_id: Optional[str] = None,
-                operator_id: Optional[str] = None) -> Union[pd.DataFrame, BinaryIO]:
+def get_dataset(
+    name: str, run_id: Optional[str] = None, operator_id: Optional[str] = None
+) -> Union[pd.DataFrame, BinaryIO]:
     """Retrieves dataset response object from minio.
 
     If run_id exists, then gets the dataset from the specified run.
@@ -169,12 +182,14 @@ def get_dataset(name: str,
     return response
 
 
-def save_dataset(name: str,
-                 data: Union[pd.DataFrame, BinaryIO] = None,
-                 df: pd.DataFrame = None,
-                 metadata: Optional[Dict[str, str]] = None,
-                 run_id: Optional[str] = None,
-                 operator_id: Optional[str] = None):
+def save_dataset(
+    name: str,
+    data: Union[pd.DataFrame, BinaryIO] = None,
+    df: pd.DataFrame = None,
+    metadata: Optional[Dict[str, str]] = None,
+    run_id: Optional[str] = None,
+    operator_id: Optional[str] = None,
+):
     """Saves a dataset and its metadata to the object storage.
 
     Args:
@@ -244,16 +259,18 @@ def save_dataset(name: str,
     # search for changes and then update current featuretypes to be even with columns
     if metadata_should_be_updated:
         previous_metadata = stat_dataset(name, run_id)
-        previous_columns = previous_metadata["columns"]
-        previous_featuretypes = previous_metadata["featuretypes"]
+        previous_columns = previous_metadata.get("columns", [])
+        previous_featuretypes = previous_metadata.get("featuretypes", [])
         column_to_type = dict(zip(previous_columns, previous_featuretypes))
 
         new_featuretypes = []
-        for new_column in metadata["columns"]:
+        for new_column in metadata.get("columns"):
             if new_column in column_to_type:
                 new_featuretypes.append(column_to_type[new_column])
             else:
-                new_featuretypes.append(infer_featuretypes(pd.DataFrame(data[new_column]))[0])
+                new_featuretypes.append(
+                    infer_featuretypes(pd.DataFrame(data[new_column]))[0]
+                )
 
         metadata["featuretypes"] = new_featuretypes
 
@@ -295,12 +312,12 @@ def save_dataset(name: str,
 
     if isinstance(data, pd.DataFrame):
         # uploads dataframe to MinIO as a .csv file
-        temp_file = tempfile.NamedTemporaryFile(dir='.', delete=False)
+        temp_file = tempfile.NamedTemporaryFile(dir=".", delete=False)
         data.to_csv(temp_file.name, header=True, index=False)
         MINIO_CLIENT.fput_object(
             bucket_name=BUCKET_NAME,
             object_name=path.lstrip(f"{BUCKET_NAME}/"),
-            file_path=temp_file.name
+            file_path=temp_file.name,
         )
         temp_file.close()
         os.remove(temp_file.name)
@@ -330,9 +347,9 @@ def raise_if_dataset_does_not_exist(err: S3Error):
         raise FileNotFoundError("The specified dataset does not exist")
 
 
-def stat_dataset(name: str,
-                 run_id: Optional[str] = None,
-                 operator_id: Optional[str] = None) -> Dict[str, str]:
+def stat_dataset(
+    name: str, run_id: Optional[str] = None, operator_id: Optional[str] = None
+) -> Dict[str, str]:
     """Retrieves the metadata of a dataset.
 
     Args:
@@ -408,15 +425,17 @@ def download_dataset(name: str, path: str):
     if isinstance(dataset, pd.DataFrame):
         dataset.to_csv(path, index=False)
     else:
-        f = open(path, 'wb')
+        f = open(path, "wb")
         f.write(dataset.getvalue())
         f.close()
 
 
-def update_dataset_metadata(name: str,
-                            metadata: Dict[str, str],
-                            run_id: Optional[str] = None,
-                            operator_id: Optional[str] = None):
+def update_dataset_metadata(
+    name: str,
+    metadata: Dict[str, str],
+    run_id: Optional[str] = None,
+    operator_id: Optional[str] = None,
+):
     """Update the metadata of a dataset.
     Args:
         name (str): the dataset name.
@@ -437,9 +456,9 @@ def update_dataset_metadata(name: str,
     )
 
 
-def _data_filepath(name: str,
-                   run_id: Optional[str] = None,
-                   operator_id: Optional[str] = None) -> str:
+def _data_filepath(
+    name: str, run_id: Optional[str] = None, operator_id: Optional[str] = None
+) -> str:
     """Builds the filepath of a given dataset.
 
     Args:
@@ -462,9 +481,9 @@ def _data_filepath(name: str,
     return path
 
 
-def _metadata_filepath(name: str,
-                       run_id: Optional[str] = None,
-                       operator_id: Optional[str] = None) -> str:
+def _metadata_filepath(
+    name: str, run_id: Optional[str] = None, operator_id: Optional[str] = None
+) -> str:
     """Builds the filepath of metadata of a given dataset.
 
     Args:
@@ -482,7 +501,7 @@ def _metadata_filepath(name: str,
 
 
 def handle_run_id(name: str, run_id: Optional[str] = None):
-    """ Check cases where handle ID is None or 'latest', returning proper value of those cases.
+    """Check cases where handle ID is None or 'latest', returning proper value of those cases.
 
     Args:
         name (str): the dataset name.

--- a/platiagro/datasets.py
+++ b/platiagro/datasets.py
@@ -11,6 +11,7 @@ from minio.error import S3Error
 from platiagro.featuretypes import CATEGORICAL, DATETIME, infer_featuretypes
 from platiagro.util import (
     BUCKET_NAME,
+    DEFAULT_PART_SIZE,
     MINIO_CLIENT,
     S3FS,
     get_operator_id,
@@ -328,7 +329,7 @@ def save_dataset(
             object_name=path.lstrip(f"{BUCKET_NAME}/"),
             data=data,
             length=-1,
-            part_size=6000000,
+            part_size=DEFAULT_PART_SIZE,
         )
 
     object_name = _metadata_filepath(name, run_id, operator_id)

--- a/platiagro/figures.py
+++ b/platiagro/figures.py
@@ -66,7 +66,7 @@ def list_figures(
     figures = []
 
     if deployment_id is not None:
-        prefix = f"deployments/{deployment_id}/monitorings/{monitoring_id}/"
+        prefix = f"deployments/{deployment_id}/monitorings/{monitoring_id}/figure-"
     else:
         prefix = operator_filepath("figure-", experiment_id, operator_id, run_id)
 

--- a/platiagro/figures.py
+++ b/platiagro/figures.py
@@ -6,16 +6,27 @@ from datetime import datetime
 
 import base64
 
-from platiagro.util import BUCKET_NAME, MINIO_CLIENT, make_bucket, \
-    get_experiment_id, get_operator_id, get_run_id, get_deployment_id, get_monitoring_id, \
-    stat_metadata, operator_filepath
+from platiagro.util import (
+    BUCKET_NAME,
+    MINIO_CLIENT,
+    make_bucket,
+    get_experiment_id,
+    get_operator_id,
+    get_run_id,
+    get_deployment_id,
+    get_monitoring_id,
+    stat_metadata,
+    operator_filepath,
+)
 
 
-def list_figures(experiment_id: Optional[str] = None,
-                 operator_id: Optional[str] = None,
-                 run_id: Optional[str] = None,
-                 deployment_id: Optional[str] = None,
-                 monitoring_id: Optional[str] = None) -> List[str]:
+def list_figures(
+    experiment_id: Optional[str] = None,
+    operator_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    deployment_id: Optional[str] = None,
+    monitoring_id: Optional[str] = None,
+) -> List[str]:
     """Lists all figures from object storage as data URI scheme.
 
     Args:
@@ -57,7 +68,7 @@ def list_figures(experiment_id: Optional[str] = None,
     if deployment_id is not None:
         prefix = f"deployments/{deployment_id}/monitorings/{monitoring_id}/"
     else:
-        prefix = operator_filepath('figure-', experiment_id, operator_id, run_id)
+        prefix = operator_filepath("figure-", experiment_id, operator_id, run_id)
 
     objects = MINIO_CLIENT.list_objects(BUCKET_NAME, prefix)
 
@@ -67,10 +78,10 @@ def list_figures(experiment_id: Optional[str] = None,
             object_name=obj.object_name,
         )
         encoded_figure = base64.b64encode(data.read()).decode()
-        file_extension = obj.object_name.split('.')[1]
-        if file_extension == 'html':
+        file_extension = obj.object_name.split(".")[1]
+        if file_extension == "html":
             figure = f"data:text/html;base64,{encoded_figure}"
-        elif file_extension == 'svg':
+        elif file_extension == "svg":
             figure = f"data:image/svg+xml;base64,{encoded_figure}"
         else:
             figure = f"data:image/{file_extension};base64,{encoded_figure}"
@@ -78,13 +89,15 @@ def list_figures(experiment_id: Optional[str] = None,
     return figures
 
 
-def save_figure(figure: Union[bytes, str],
-                extension: Optional[str] = None,
-                experiment_id: Optional[str] = None,
-                operator_id: Optional[str] = None,
-                run_id: Optional[str] = None,
-                deployment_id: Optional[str] = None,
-                monitoring_id: Optional[str] = None):
+def save_figure(
+    figure: Union[bytes, str],
+    extension: Optional[str] = None,
+    experiment_id: Optional[str] = None,
+    operator_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    deployment_id: Optional[str] = None,
+    monitoring_id: Optional[str] = None,
+):
     """Saves a figure to the object storage.
 
     Args:
@@ -120,6 +133,9 @@ def save_figure(figure: Union[bytes, str],
         # Attention: returns None if env is unset
         monitoring_id = get_monitoring_id()
 
+    # ensures MinIO bucket exists
+    make_bucket(BUCKET_NAME)
+
     if run_id:
         metadata = {}
         try:
@@ -134,12 +150,12 @@ def save_figure(figure: Union[bytes, str],
         buffer = BytesIO(dumps(metadata).encode())
         MINIO_CLIENT.put_object(
             bucket_name=BUCKET_NAME,
-            object_name=f'experiments/{experiment_id}/operators/{operator_id}/.metadata',
+            object_name=f"experiments/{experiment_id}/operators/{operator_id}/.metadata",
             data=buffer,
             length=buffer.getbuffer().nbytes,
         )
 
-    if extension == 'html':
+    if extension == "html":
         buffer = BytesIO(figure.encode())
     else:
         buffer = BytesIO(base64.b64decode(figure))
@@ -151,7 +167,9 @@ def save_figure(figure: Union[bytes, str],
 
     # uploads figure to MinIO
     if deployment_id is not None:
-        object_name = f"deployments/{deployment_id}/monitorings/{monitoring_id}/{figure_name}"
+        object_name = (
+            f"deployments/{deployment_id}/monitorings/{monitoring_id}/{figure_name}"
+        )
     else:
         object_name = operator_filepath(figure_name, experiment_id, operator_id, run_id)
 
@@ -163,11 +181,13 @@ def save_figure(figure: Union[bytes, str],
     )
 
 
-def delete_figures(experiment_id: Optional[str] = None,
-                   operator_id: Optional[str] = None,
-                   run_id: Optional[str] = None,
-                   deployment_id: Optional[str] = None,
-                   monitoring_id: Optional[str] = None) -> List[str]:
+def delete_figures(
+    experiment_id: Optional[str] = None,
+    operator_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    deployment_id: Optional[str] = None,
+    monitoring_id: Optional[str] = None,
+) -> List[str]:
     """Delete a figure to the object storage.
 
     Args:
@@ -190,6 +210,9 @@ def delete_figures(experiment_id: Optional[str] = None,
     if monitoring_id is None:
         monitoring_id = get_monitoring_id()
 
+    # ensures MinIO bucket exists
+    make_bucket(BUCKET_NAME)
+
     if run_id:
         metadata = {}
         try:
@@ -200,9 +223,9 @@ def delete_figures(experiment_id: Optional[str] = None,
             pass
 
     if deployment_id is not None:
-        prefix = f"deployments/{deployment_id}/monitorings/{monitoring_id}/"
+        prefix = f"deployments/{deployment_id}/monitorings/{monitoring_id}/figure-"
     else:
-        prefix = operator_filepath('figure-', experiment_id, operator_id, run_id)
+        prefix = operator_filepath("figure-", experiment_id, operator_id, run_id)
 
     objects = MINIO_CLIENT.list_objects(BUCKET_NAME, prefix)
 

--- a/platiagro/io.py
+++ b/platiagro/io.py
@@ -1,6 +1,13 @@
+# -*- coding: utf-8 -*-
 import zipfile
 
 
-def unzip_to_folder(path_to_zip_file, directory_to_extract_to):
-    with zipfile.ZipFile(path_to_zip_file, 'r') as zip_ref:
+def unzip_to_folder(path_to_zip_file: str, directory_to_extract_to: str):
+    """Unzips .zip file into a given directory.
+
+    Args:
+        path_to_zip_file (str): path to zipfile.
+        directory_to_extract_to (str): destination path.
+    """
+    with zipfile.ZipFile(path_to_zip_file, "r") as zip_ref:
         zip_ref.extractall(directory_to_extract_to)

--- a/platiagro/util.py
+++ b/platiagro/util.py
@@ -42,7 +42,7 @@ def make_bucket(name: str):
         MINIO_CLIENT.make_bucket(name)
     except S3Error as err:
         if err.code == "BucketAlreadyOwnedByYou":
-            logging.warning("The bucket already exists.")
+            logging.debug("The bucket already exists.")
 
 
 def get_experiment_id(raise_for_none: bool = False, default: Optional[str] = None):

--- a/platiagro/util.py
+++ b/platiagro/util.py
@@ -10,10 +10,12 @@ from typing import Dict
 import logging
 
 BUCKET_NAME = "anonymous"
-MINIO_ENDPOINT = getenv("MINIO_ENDPOINT", "minio-service.kubeflow:9000")
+MINIO_ENDPOINT = getenv("MINIO_ENDPOINT", "minio-service.platiagro:9000")
 MINIO_ACCESS_KEY = getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = getenv("MINIO_SECRET_KEY", "minio123")
-JUPYTER_ENDPOINT = getenv("JUPYTER_ENDPOINT", "http://server.anonymous:80/notebook/anonymous/server")
+JUPYTER_ENDPOINT = getenv(
+    "JUPYTER_ENDPOINT", "http://server.anonymous:80/notebook/anonymous/server"
+)
 
 MINIO_CLIENT = Minio(
     endpoint=MINIO_ENDPOINT,
@@ -185,7 +187,7 @@ def stat_metadata(experiment_id: str, operator_id: str) -> Dict[str, str]:
         FileNotFoundError: If metadata does not exist in the object storage.
     """
     metadata = {}
-    object_name = f'experiments/{experiment_id}/operators/{operator_id}/.metadata'
+    object_name = f"experiments/{experiment_id}/operators/{operator_id}/.metadata"
     try:
         # reads the .metadata file
         data = MINIO_CLIENT.get_object(
@@ -215,11 +217,11 @@ def metadata_exists(name: str, run_id: str = None, operator_id: str = None) -> b
         bool: True if metadata path exists in the obeject storage, otherwise, False.
     """
     if run_id and operator_id:
-        object_name = f'datasets/{name}/runs/{run_id}/operators/{operator_id}/{name}/{name}.metadata'
+        object_name = f"datasets/{name}/runs/{run_id}/operators/{operator_id}/{name}/{name}.metadata"
     elif run_id:
-        object_name = f'datasets/{name}/runs/{run_id}/{run_id}.metadata'
+        object_name = f"datasets/{name}/runs/{run_id}/{run_id}.metadata"
     else:
-        object_name = f'datasets/{name}/{name}.metadata'
+        object_name = f"datasets/{name}/{name}.metadata"
 
     try:
         # reads the .metadata file
@@ -233,10 +235,12 @@ def metadata_exists(name: str, run_id: str = None, operator_id: str = None) -> b
             return False
 
 
-def operator_filepath(name: str,
-                      experiment_id: Optional[str] = None,
-                      operator_id: Optional[str] = None,
-                      run_id: Optional[str] = None) -> str:
+def operator_filepath(
+    name: str,
+    experiment_id: Optional[str] = None,
+    operator_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> str:
     """Builds the filepath of a given operator.
     Args:
         name (str): the file name.
@@ -247,7 +251,7 @@ def operator_filepath(name: str,
         str: The object name.
     """
     if run_id:
-        path = f'experiments/{experiment_id}/operators/{operator_id}/{run_id}/{name}'
+        path = f"experiments/{experiment_id}/operators/{operator_id}/{run_id}/{name}"
     else:
-        path = f'experiments/{experiment_id}/operators/{operator_id}/{name}'
+        path = f"experiments/{experiment_id}/operators/{operator_id}/{name}"
     return path

--- a/platiagro/util.py
+++ b/platiagro/util.py
@@ -10,7 +10,7 @@ from typing import Dict
 import logging
 
 BUCKET_NAME = "anonymous"
-MINIO_ENDPOINT = getenv("MINIO_ENDPOINT", "minio-service.platiagro:9000")
+MINIO_ENDPOINT = getenv("MINIO_ENDPOINT", "minio.platiagro:9000")
 MINIO_ACCESS_KEY = getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = getenv("MINIO_SECRET_KEY", "minio123")
 

--- a/platiagro/util.py
+++ b/platiagro/util.py
@@ -13,6 +13,7 @@ BUCKET_NAME = "anonymous"
 MINIO_ENDPOINT = getenv("MINIO_ENDPOINT", "minio.platiagro:9000")
 MINIO_ACCESS_KEY = getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = getenv("MINIO_SECRET_KEY", "minio123")
+DEFAULT_PART_SIZE = 6000000  # 6MB
 
 MINIO_CLIENT = Minio(
     endpoint=MINIO_ENDPOINT,

--- a/platiagro/util.py
+++ b/platiagro/util.py
@@ -13,9 +13,6 @@ BUCKET_NAME = "anonymous"
 MINIO_ENDPOINT = getenv("MINIO_ENDPOINT", "minio-service.platiagro:9000")
 MINIO_ACCESS_KEY = getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = getenv("MINIO_SECRET_KEY", "minio123")
-JUPYTER_ENDPOINT = getenv(
-    "JUPYTER_ENDPOINT", "http://server.anonymous:80/notebook/anonymous/server"
-)
 
 MINIO_CLIENT = Minio(
     endpoint=MINIO_ENDPOINT,

--- a/tests/client/test_deployments.py
+++ b/tests/client/test_deployments.py
@@ -1,47 +1,61 @@
-import pytest
-from unittest import mock, TestCase
+# -*- coding: utf-8 -*-
+import unittest
+import unittest.mock as mock
 
-from platiagro.client.deployments import list_deployments, get_deployment_by_name
+import platiagro.client.deployments
 
 PROJECT_ID = "c862813f-13e8-4adb-a430-56a1444209a0"
 
 DEPLOYMENT_NAME = "deployment00"
 DEPLOYMENTS_LIST = {
     "deployments": [
-        {
-            "uuid": "b793c517-2f95-41f0-a4bb-25da50d6e052",
-            "name": "deployment01"
-        },
-        {
-            "uuid": "ea5661ab-28fe-4531-b310-8a37bd77197b",
-            "name": DEPLOYMENT_NAME
-        }
+        {"uuid": "b793c517-2f95-41f0-a4bb-25da50d6e052", "name": "deployment01"},
+        {"uuid": "ea5661ab-28fe-4531-b310-8a37bd77197b", "name": DEPLOYMENT_NAME},
     ]
 }
 
 
-class TestRuns(TestCase):
-
+class TestDeployments(unittest.TestCase):
     @mock.patch("platiagro.client.deployments.requests.get")
     def test_list_deployments(self, mock_get):
+        """
+        Should return a list of two deployments.
+        """
         mock_response = mock.Mock(status_code=200)
         mock_response.json.return_value = DEPLOYMENTS_LIST
         mock_get.return_value = mock_response
 
-        result = list_deployments(project_id=PROJECT_ID)
+        result = platiagro.client.deployments.list_deployments(project_id=PROJECT_ID)
+
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json(), DEPLOYMENTS_LIST)
 
     @mock.patch("platiagro.client.deployments.list_deployments")
-    def test_get_experiment_by_name(self, mock_list_deployments):
+    def test_get_deployment_by_name_value_error(self, mock_list_deployments):
+        """
+        Should raise an exception when deployment_name does not exist.
+        """
         mock_response = mock.Mock(status_code=200)
         mock_response.json.return_value = DEPLOYMENTS_LIST
         mock_list_deployments.return_value = mock_response
 
-        with pytest.raises(ValueError):
-            assert get_deployment_by_name(project_id=PROJECT_ID, deployment_name="unk")
+        with self.assertRaises(ValueError):
+            assert platiagro.client.deployments.get_deployment_by_name(
+                project_id=PROJECT_ID, deployment_name="unk"
+            )
 
-        result = get_deployment_by_name(project_id=PROJECT_ID, deployment_name=DEPLOYMENT_NAME)
+    @mock.patch("platiagro.client.deployments.list_deployments")
+    def test_get_deployment_by_name_success(self, mock_list_deployments):
+        """
+        Should return deployment_name successfully.
+        """
+        mock_response = mock.Mock(status_code=200)
+        mock_response.json.return_value = DEPLOYMENTS_LIST
+        mock_list_deployments.return_value = mock_response
+
+        result = platiagro.client.deployments.get_deployment_by_name(
+            project_id=PROJECT_ID, deployment_name=DEPLOYMENT_NAME
+        )
         self.assertIsInstance(result, dict)
         self.assertEqual(result["name"], DEPLOYMENT_NAME)
 

--- a/tests/client/test_experiments.py
+++ b/tests/client/test_experiments.py
@@ -1,47 +1,60 @@
 # -*- coding: utf-8 -*-
-import pytest
-from unittest import mock, TestCase
+import unittest
+import unittest.mock as mock
 
-from platiagro.client.experiments import get_experiment_by_name, list_experiments
+import platiagro.client.experiments
 
 PROJECT_ID = "c862813f-13e8-4adb-a430-56a1444209a0"
 
 EXPERIMENT_NAME = "experiment00"
 EXPERIMENTS_LIST = {
     "experiments": [
-        {
-            "uuid": "bc4a0874-4a6b-4e20-bd7e-ed00c51fd8ea",
-            "name": "experiment01"
-        },
-        {
-            "uuid": "a8ab15b1-7a90-4f18-b18d-e14f7422c938",
-            "name": EXPERIMENT_NAME
-        }
+        {"uuid": "bc4a0874-4a6b-4e20-bd7e-ed00c51fd8ea", "name": "experiment01"},
+        {"uuid": "a8ab15b1-7a90-4f18-b18d-e14f7422c938", "name": EXPERIMENT_NAME},
     ]
 }
 
-class TestRuns(TestCase):
-    
+
+class TestExperiments(unittest.TestCase):
     @mock.patch("platiagro.client.experiments.requests.get")
     def test_list_experiments(self, mock_get):
+        """
+        Should return a list of two experiments.
+        """
         mock_response = mock.Mock(status_code=200)
         mock_response.json.return_value = EXPERIMENTS_LIST
         mock_get.return_value = mock_response
 
-        result = list_experiments(project_id=PROJECT_ID)
+        result = platiagro.client.experiments.list_experiments(project_id=PROJECT_ID)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json(), EXPERIMENTS_LIST)
 
     @mock.patch("platiagro.client.experiments.list_experiments")
-    def test_get_experiment_by_name(self, mock_list_experiments):
+    def test_get_experiment_by_name_value_error(self, mock_list_experiments):
+        """
+        Should raise an exception when experiment_name does not exist.
+        """
         mock_response = mock.Mock(status_code=200)
         mock_response.json.return_value = EXPERIMENTS_LIST
         mock_list_experiments.return_value = mock_response
 
-        with pytest.raises(ValueError):
-            assert get_experiment_by_name(project_id=PROJECT_ID, experiment_name="unk")
+        with self.assertRaises(ValueError):
+            assert platiagro.client.experiments.get_experiment_by_name(
+                project_id=PROJECT_ID, experiment_name="unk"
+            )
 
-        result = get_experiment_by_name(project_id=PROJECT_ID, experiment_name=EXPERIMENT_NAME)
+    @mock.patch("platiagro.client.experiments.list_experiments")
+    def test_get_experiment_by_name_success(self, mock_list_experiments):
+        """
+        Should return experiment_name successfully.
+        """
+        mock_response = mock.Mock(status_code=200)
+        mock_response.json.return_value = EXPERIMENTS_LIST
+        mock_list_experiments.return_value = mock_response
+
+        result = platiagro.client.experiments.get_experiment_by_name(
+            project_id=PROJECT_ID, experiment_name=EXPERIMENT_NAME
+        )
         self.assertIsInstance(result, dict)
         self.assertEqual(result["name"], EXPERIMENT_NAME)
 

--- a/tests/client/test_projects.py
+++ b/tests/client/test_projects.py
@@ -1,44 +1,55 @@
 # -*- coding: utf-8 -*-
-import pytest
-from unittest import mock, TestCase
+import unittest
+import unittest.mock as mock
 
-from platiagro.client.projects import get_project_by_name, list_projects
+import platiagro.client.projects
 
 PROJECT_NAME = "project00"
 PROJECTS_LIST = {
     "projects": [
-        {
-            "uuid": "c862813f-13e8-4adb-a430-56a1444209a0",
-            "name": "project01"
-        },
-        {
-            "uuid": "e2ea6c34-2ace-4a5d-a97c-ca60e9ef92ec",
-            "name": PROJECT_NAME
-        }
+        {"uuid": "c862813f-13e8-4adb-a430-56a1444209a0", "name": "project01"},
+        {"uuid": "e2ea6c34-2ace-4a5d-a97c-ca60e9ef92ec", "name": PROJECT_NAME},
     ]
 }
 
-class TestRuns(TestCase):
 
+class TestProjects(unittest.TestCase):
     @mock.patch("requests.get")
     def test_list_projects(self, mock_get):
+        """
+        Should return a list of two projects.
+        """
         mock_response = mock.Mock(status_code=200)
         mock_response.json.return_value = PROJECTS_LIST
         mock_get.return_value = mock_response
 
-        result = list_projects()
+        result = platiagro.client.projects.list_projects()
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json(), PROJECTS_LIST)
 
     @mock.patch("platiagro.client.projects.list_projects")
-    def test_get_experiment_by_name(self, mock_list_projects):
+    def test_get_project_by_name_value_error(self, mock_list_projects):
+        """
+        Should raise an exception when project_name does not exist.
+        """
         mock_response = mock.Mock(status_code=200)
         mock_response.json.return_value = PROJECTS_LIST
         mock_list_projects.return_value = mock_response
 
-        with pytest.raises(ValueError):
-            assert get_project_by_name(project_name="unk")
+        with self.assertRaises(ValueError):
+            assert platiagro.client.projects.get_project_by_name(project_name="unk")
 
-        result = get_project_by_name(project_name=PROJECT_NAME)
+    @mock.patch("platiagro.client.projects.list_projects")
+    def test_get_project_by_name_success(self, mock_list_projects):
+        """
+        Should return project_name successfully.
+        """
+        mock_response = mock.Mock(status_code=200)
+        mock_response.json.return_value = PROJECTS_LIST
+        mock_list_projects.return_value = mock_response
+
+        result = platiagro.client.projects.get_project_by_name(
+            project_name=PROJECT_NAME
+        )
         self.assertIsInstance(result, dict)
         self.assertEqual(result["name"], PROJECT_NAME)

--- a/tests/client/test_tasks.py
+++ b/tests/client/test_tasks.py
@@ -1,15 +1,19 @@
-from unittest import mock, TestCase
-from platiagro.client.tasks import create_task
+# -*- coding: utf-8 -*-
+import unittest
+import unittest.mock as mock
+
+import platiagro.client.tasks
 
 
-class TestTasks(TestCase):
+class TestTasks(unittest.TestCase):
     @mock.patch("platiagro.client.tasks.requests.post")
     def test_create_tasks(self, mock_post):
+        """
+        Should create a task.
+        """
         mock_response = mock.Mock(status_code=200)
-        mock_response.json.return_value = {
-            "name": "TestTasks"
-        }
+        mock_response.json.return_value = {"name": "TestTasks"}
         mock_post.return_value = mock_response
 
-        response = create_task("TestTasks")
+        response = platiagro.client.tasks.create_task("TestTasks")
         self.assertEqual(response.status_code, 200)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -3,9 +3,6 @@ import os
 import unittest
 import unittest.mock as mock
 
-from minio import Minio
-from minio.error import S3Error
-
 import platiagro
 from platiagro.util import MINIO_CLIENT
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -4,7 +4,7 @@ import unittest
 import unittest.mock as mock
 
 import platiagro
-from platiagro.util import MINIO_CLIENT
+from platiagro.util import BUCKET_NAME, MINIO_CLIENT
 
 import tests.util as util
 
@@ -25,6 +25,12 @@ class TestArtifacts(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             platiagro.download_artifact(name=bad_artifact_name, path=local_path)
 
+        mock_fget_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"artifacts/{bad_artifact_name}",
+            file_path=local_path,
+        )
+
     @mock.patch.object(
         MINIO_CLIENT,
         "fget_object",
@@ -39,3 +45,9 @@ class TestArtifacts(unittest.TestCase):
 
         platiagro.download_artifact(name=artifact_name, path=local_path)
         self.assertTrue(os.path.exists(local_path))
+
+        mock_fget_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"artifacts/{artifact_name}",
+            file_path=local_path,
+        )

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -9,19 +9,14 @@ from minio.error import S3Error
 import platiagro
 from platiagro.util import MINIO_CLIENT
 
+import tests.util as util
+
 
 class TestArtifacts(unittest.TestCase):
     @mock.patch.object(
         MINIO_CLIENT,
         "fget_object",
-        side_effect=S3Error(
-            code="NoSuchKey",
-            message="",
-            resource=None,
-            request_id=None,
-            host_id=None,
-            response=None,
-        ),
+        side_effect=util.NO_SUCH_KEY_ERROR,
     )
     def test_download_artifact_not_found(self, mock_fget_object):
         """

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,53 +1,49 @@
 # -*- coding: utf-8 -*-
-import io
 import os
-from unittest import TestCase
+import unittest
+import unittest.mock as mock
 
+from minio import Minio
 from minio.error import S3Error
 
-from platiagro import download_artifact
-from platiagro.util import BUCKET_NAME, MINIO_CLIENT
+import platiagro
+from platiagro.util import MINIO_CLIENT
 
 
-class TestArtifacts(TestCase):
+class TestArtifacts(unittest.TestCase):
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "fget_object",
+        side_effect=S3Error(
+            code="NoSuchKey",
+            message="",
+            resource=None,
+            request_id=None,
+            host_id=None,
+            response=None,
+        ),
+    )
+    def test_download_artifact_not_found(self, mock_fget_object):
+        """
+        Should raise an exception when given an artifact name that does not exist.
+        """
+        bad_artifact_name = "unk.zip"
+        local_path = "./unk.zip"
 
-    def setUp(self):
-        self.make_bucket()
-        buffer = io.BytesIO(b"mock")
-        MINIO_CLIENT.put_object(
-            bucket_name=BUCKET_NAME,
-            object_name="artifacts/mock.txt",
-            data=buffer,
-            length=buffer.getbuffer().nbytes,
-        )
-
-    def tearDown(self):
-        MINIO_CLIENT.remove_object(
-            bucket_name=BUCKET_NAME,
-            object_name="artifacts/mock.txt",
-        )
-
-    def make_bucket(self):
-        try:
-            MINIO_CLIENT.make_bucket(BUCKET_NAME)
-        except S3Error as err:
-            if err.code == "BucketAlreadyOwnedByYou":
-                pass
-            if err.code == "NoSuchBucket" or err.code == "NoSuchKey":
-                raise FileNotFoundError("The specified artifact does not exist")
-
-    def test_download_artifact(self):
         with self.assertRaises(FileNotFoundError):
-            download_artifact("unk.zip", "./unk.zip")
+            platiagro.download_artifact(name=bad_artifact_name, path=local_path)
 
-        download_artifact("mock.txt", "./mock-dest.txt")
-        self.assertTrue(os.path.exists("./mock-dest.txt"))
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "fget_object",
+        side_effect=lambda **kwargs: open("unk.zip", "w").close(),
+    )
+    def test_download_artifact_success(self, mock_fget_object):
+        """
+        Should download an artifact to a given local path.
+        """
+        artifact_name = "unk.zip"
+        local_path = "./unk.zip"
 
-        try:
-            MINIO_CLIENT.remove_object(
-                bucket_name=BUCKET_NAME,
-                object_name="artifacts/mock.txt",
-            )
-        except S3Error as err:
-            err.code == "NoSuchBucket"
-            self.assertEqual(err.code, S3Error)
+        platiagro.download_artifact(name=artifact_name, path=local_path)
+        self.assertTrue(os.path.exists(local_path))

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -44,7 +44,7 @@ class TestDatasets(unittest.TestCase):
         "get_object",
         side_effect=util.NO_SUCH_KEY_ERROR,
     )
-    def test_load_dataset_not_found(self, mock_list_objects, mock_make_bucket):
+    def test_load_dataset_not_found(self, mock_get_object, mock_make_bucket):
         """
         Should raise an exception when given a dataset name that does not exist.
         """
@@ -55,7 +55,7 @@ class TestDatasets(unittest.TestCase):
 
         mock_make_bucket.assert_any_call(BUCKET_NAME)
 
-        mock_list_objects.assert_any_call(
+        mock_get_object.assert_any_call(
             bucket_name=BUCKET_NAME,
             object_name=f"datasets/{bad_dataset_name}/{bad_dataset_name}.metadata",
         )
@@ -149,7 +149,7 @@ class TestDatasets(unittest.TestCase):
         Should return a pandas DataFrame object when run_id and operator_id exist.
         """
         dataset_name = "unk.csv"
-        run_id = "latest"
+        run_id = "UNK"
         operator_id = "UNK"
 
         result = platiagro.load_dataset(
@@ -225,7 +225,7 @@ class TestDatasets(unittest.TestCase):
         Should return a readable object when run_id and operator_id exist.
         """
         dataset_name = "unk.csv"
-        run_id = "latest"
+        run_id = "UNK"
         operator_id = "UNK"
 
         result = platiagro.get_dataset(
@@ -390,7 +390,7 @@ class TestDatasets(unittest.TestCase):
         Should return a dict object when run_id and operator_id exist.
         """
         dataset_name = "unk.csv"
-        run_id = "latest"
+        run_id = "UNK"
         operator_id = "UNK"
 
         result = platiagro.stat_dataset(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,7 +8,7 @@ import pandas as pd
 from minio.datatypes import Object
 
 import platiagro
-from platiagro.util import BUCKET_NAME, MINIO_CLIENT, S3FS
+from platiagro.util import BUCKET_NAME, DEFAULT_PART_SIZE, MINIO_CLIENT, S3FS
 
 import tests.util as util
 
@@ -209,13 +209,13 @@ class TestDatasets(unittest.TestCase):
             length=mock.ANY,
         )
 
-        # BUG not sure why this assert fails...
-        # mock_put_object.assert_any_call(
-        #     bucket_name=BUCKET_NAME,
-        #     object_name=f"datasets/{dataset_name}/{dataset_name}",
-        #     data=mock.ANY,
-        #     length=mock.ANY,
-        # )
+        mock_put_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"datasets/{dataset_name}/{dataset_name}",
+            data=mock.ANY,
+            length=mock.ANY,
+            part_size=DEFAULT_PART_SIZE,
+        )
 
     @mock.patch.object(MINIO_CLIENT, "make_bucket")
     @mock.patch.object(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import io
 import os
-from platiagro.datasets import PREFIX
 import unittest
 import unittest.mock as mock
 
@@ -9,6 +8,7 @@ import pandas as pd
 from minio.datatypes import Object
 
 import platiagro
+from platiagro.datasets import PREFIX
 from platiagro.util import BUCKET_NAME, DEFAULT_PART_SIZE, MINIO_CLIENT, S3FS
 
 import tests.util as util
@@ -149,7 +149,7 @@ class TestDatasets(unittest.TestCase):
         Should return a pandas DataFrame object when run_id and operator_id exist.
         """
         dataset_name = "unk.csv"
-        run_id = "UNK"
+        run_id = "latest"
         operator_id = "UNK"
 
         result = platiagro.load_dataset(
@@ -225,7 +225,7 @@ class TestDatasets(unittest.TestCase):
         Should return a readable object when run_id and operator_id exist.
         """
         dataset_name = "unk.csv"
-        run_id = "UNK"
+        run_id = "latest"
         operator_id = "UNK"
 
         result = platiagro.get_dataset(
@@ -390,7 +390,7 @@ class TestDatasets(unittest.TestCase):
         Should return a dict object when run_id and operator_id exist.
         """
         dataset_name = "unk.csv"
-        run_id = "UNK"
+        run_id = "latest"
         operator_id = "UNK"
 
         result = platiagro.stat_dataset(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,327 +1,401 @@
 # -*- coding: utf-8 -*-
+import io
 import os
-from base64 import b64decode
-from io import BytesIO
-from json import dumps
-from unittest import TestCase
-from uuid import uuid4
-from zipfile import ZipFile
+import unittest
+import unittest.mock as mock
 
 import pandas as pd
-from minio.commonconfig import CopySource
+from minio.datatypes import Object
 from minio.error import S3Error
+from urllib3.response import HTTPResponse
 
-from platiagro import (CATEGORICAL, DATETIME, NUMERICAL, download_dataset,
-                       get_dataset, list_datasets, load_dataset, save_dataset,
-                       stat_dataset, update_dataset_metadata)
-from platiagro.util import BUCKET_NAME, MINIO_CLIENT
+import platiagro
+from platiagro.util import BUCKET_NAME, MINIO_CLIENT, S3FS
 
-RUN_ID = str(uuid4())
-OPERATOR_ID = str(uuid4())
-MOCK_IMAGE = b64decode("R0lGODlhPQBEAPeoAJosM//AwO/AwHVYZ/z595kzAP/s7P+goOXMv8+fhw/v739/f+8PD98fH/8mJl+fn/9ZWb8/PzWlwv///6wWGbImAPgTEMImIN9gUFCEm/gDALULDN8PAD6atYdCTX9gUNKlj8wZAKUsAOzZz+UMAOsJAP/Z2ccMDA8PD/95eX5NWvsJCOVNQPtfX/8zM8+QePLl38MGBr8JCP+zs9myn/8GBqwpAP/GxgwJCPny78lzYLgjAJ8vAP9fX/+MjMUcAN8zM/9wcM8ZGcATEL+QePdZWf/29uc/P9cmJu9MTDImIN+/r7+/vz8/P8VNQGNugV8AAF9fX8swMNgTAFlDOICAgPNSUnNWSMQ5MBAQEJE3QPIGAM9AQMqGcG9vb6MhJsEdGM8vLx8fH98AANIWAMuQeL8fABkTEPPQ0OM5OSYdGFl5jo+Pj/+pqcsTE78wMFNGQLYmID4dGPvd3UBAQJmTkP+8vH9QUK+vr8ZWSHpzcJMmILdwcLOGcHRQUHxwcK9PT9DQ0O/v70w5MLypoG8wKOuwsP/g4P/Q0IcwKEswKMl8aJ9fX2xjdOtGRs/Pz+Dg4GImIP8gIH0sKEAwKKmTiKZ8aB/f39Wsl+LFt8dgUE9PT5x5aHBwcP+AgP+WltdgYMyZfyywz78AAAAAAAD///8AAP9mZv///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAAKgALAAAAAA9AEQAAAj/AFEJHEiwoMGDCBMqXMiwocAbBww4nEhxoYkUpzJGrMixogkfGUNqlNixJEIDB0SqHGmyJSojM1bKZOmyop0gM3Oe2liTISKMOoPy7GnwY9CjIYcSRYm0aVKSLmE6nfq05QycVLPuhDrxBlCtYJUqNAq2bNWEBj6ZXRuyxZyDRtqwnXvkhACDV+euTeJm1Ki7A73qNWtFiF+/gA95Gly2CJLDhwEHMOUAAuOpLYDEgBxZ4GRTlC1fDnpkM+fOqD6DDj1aZpITp0dtGCDhr+fVuCu3zlg49ijaokTZTo27uG7Gjn2P+hI8+PDPERoUB318bWbfAJ5sUNFcuGRTYUqV/3ogfXp1rWlMc6awJjiAAd2fm4ogXjz56aypOoIde4OE5u/F9x199dlXnnGiHZWEYbGpsAEA3QXYnHwEFliKAgswgJ8LPeiUXGwedCAKABACCN+EA1pYIIYaFlcDhytd51sGAJbo3onOpajiihlO92KHGaUXGwWjUBChjSPiWJuOO/LYIm4v1tXfE6J4gCSJEZ7YgRYUNrkji9P55sF/ogxw5ZkSqIDaZBV6aSGYq/lGZplndkckZ98xoICbTcIJGQAZcNmdmUc210hs35nCyJ58fgmIKX5RQGOZowxaZwYA+JaoKQwswGijBV4C6SiTUmpphMspJx9unX4KaimjDv9aaXOEBteBqmuuxgEHoLX6Kqx+yXqqBANsgCtit4FWQAEkrNbpq7HSOmtwag5w57GrmlJBASEU18ADjUYb3ADTinIttsgSB1oJFfA63bduimuqKB1keqwUhoCSK374wbujvOSu4QG6UvxBRydcpKsav++Ca6G8A6Pr1x2kVMyHwsVxUALDq/krnrhPSOzXG1lUTIoffqGR7Goi2MAxbv6O2kEG56I7CSlRsEFKFVyovDJoIRTg7sugNRDGqCJzJgcKE0ywc0ELm6KBCCJo8DIPFeCWNGcyqNFE06ToAfV0HBRgxsvLThHn1oddQMrXj5DyAQgjEHSAJMWZwS3HPxT/QMbabI/iBCliMLEJKX2EEkomBAUCxRi42VDADxyTYDVogV+wSChqmKxEKCDAYFDFj4OmwbY7bDGdBhtrnTQYOigeChUmc1K3QTnAUfEgGFgAWt88hKA6aCRIXhxnQ1yg3BCayK44EWdkUQcBByEQChFXfCB776aQsG0BIlQgQgE8qO26X1h8cEUep8ngRBnOy74E9QgRgEAC8SvOfQkh7FDBDmS43PmGoIiKUUEGkMEC/PJHgxw0xH74yx/3XnaYRJgMB8obxQW6kL9QYEJ0FIFgByfIL7/IQAlvQwEpnAC7DtLNJCKUoO/w45c44GwCXiAFB/OXAATQryUxdN4LfFiwgjCNYg+kYMIEFkCKDs6PKAIJouyGWMS1FSKJOMRB/BoIxYJIUXFUxNwoIkEKPAgCBZSQHQ1A2EWDfDEUVLyADj5AChSIQW6gu10bE/JG2VnCZGfo4R4d0sdQoBAHhPjhIB94v/wRoRKQWGRHgrhGSQJxCS+0pCZbEhAAOw==")
+import tests.util as util
 
 
-class TestDatasets(TestCase):
+class TestDatasets(unittest.TestCase):
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "list_objects",
+        return_value=[
+            Object(bucket_name=BUCKET_NAME, object_name=f"datasets/unk.zip/")
+        ],
+    )
+    def test_list_datasets_success(self, mock_list_objects, mock_make_bucket):
+        """
+        Should list a single dataset name "unk.zip".
+        """
+        dataset_name = "unk.zip"
 
-    def setUp(self):
-        """Prepares a dataset for tests."""
-        self.make_bucket()
-        self.empty_bucket()
-        self.create_mock_dataset1()
-        self.create_mock_dataset2()
-        self.create_mock_dataset3()
-        self.delete_downloaded_files()
-
-    def tearDown(self):
-        self.empty_bucket()
-
-    def empty_bucket(self):
-        for obj in MINIO_CLIENT.list_objects(BUCKET_NAME, prefix="", recursive=True):
-            MINIO_CLIENT.remove_object(BUCKET_NAME, obj.object_name)
-
-    def make_bucket(self):
-        try:
-            MINIO_CLIENT.make_bucket(BUCKET_NAME)
-        except S3Error as err:
-            if err.code == "BucketAlreadyOwnedByYou":
-                pass
-
-    def mock_columns(self, size=1e3):
-        return [f"col{i}" for i in range(int(size))]
-
-    def mock_values(self, size=1e3):
-        values = ["01/01/2000", 5.1, 3.5, 1.4, 0.2, "Iris-setosa"]
-        return [values[i % len(values)] for i in range(int(size))]
-
-    def mock_featuretypes(self, size=1e3):
-        ftypes = [DATETIME, NUMERICAL, NUMERICAL,
-                  NUMERICAL, NUMERICAL, CATEGORICAL]
-        return [ftypes[i % len(ftypes)] for i in range(int(size))]
-
-    def create_mock_dataset1(self, size=1e2):
-        header = ",".join(self.mock_columns()) + "\n"
-        rows = "\n".join([",".join([str(v) for v in self.mock_values()])
-                          for x in range(int(size))])
-        buffer = BytesIO((header + rows).encode())
-        MINIO_CLIENT.put_object(
-            bucket_name=BUCKET_NAME,
-            object_name="datasets/mock.csv/mock.csv",
-            data=buffer,
-            length=buffer.getbuffer().nbytes,
-        )
-        metadata = {
-            "columns": self.mock_columns(),
-            "featuretypes": self.mock_featuretypes(),
-            "filename": "mock.csv",
-            "run_id": RUN_ID,
-        }
-        buffer = BytesIO(dumps(metadata).encode())
-        MINIO_CLIENT.put_object(
-            bucket_name=BUCKET_NAME,
-            object_name="datasets/mock.csv/mock.csv.metadata",
-            data=buffer,
-            length=buffer.getbuffer().nbytes,
-        )
-        MINIO_CLIENT.copy_object(
-            bucket_name=BUCKET_NAME,
-            object_name=f"datasets/mock.csv/runs/{RUN_ID}/operators/{OPERATOR_ID}/mock.csv/mock.csv",
-            source=CopySource(BUCKET_NAME, "datasets/mock.csv/mock.csv")
-        )
-        MINIO_CLIENT.copy_object(
-            bucket_name=BUCKET_NAME,
-            object_name=f"datasets/mock.csv/runs/{RUN_ID}/operators/{OPERATOR_ID}/mock.csv/mock.csv.metadata",
-            source=CopySource(BUCKET_NAME, "datasets/mock.csv/mock.csv.metadata")
-        )
-
-    def create_mock_dataset2(self):
-        with ZipFile("mock.zip", "w") as zipf:
-            zipf.writestr("mock.gif", MOCK_IMAGE)
-
-        MINIO_CLIENT.fput_object(
-            bucket_name=BUCKET_NAME,
-            object_name="datasets/mock.zip/mock.zip",
-            file_path="mock.zip",
-        )
-        metadata = {
-            "filename": "mock.zip",
-        }
-        buffer = BytesIO(dumps(metadata).encode())
-        MINIO_CLIENT.put_object(
-            bucket_name=BUCKET_NAME,
-            object_name="datasets/mock.zip/mock.zip.metadata",
-            data=buffer,
-            length=buffer.getbuffer().nbytes,
-        )
-
-    def create_mock_dataset3(self):
-        with open("mock.jpg", 'wb') as imagef:
-            imagef.write(MOCK_IMAGE)
-
-        MINIO_CLIENT.fput_object(
-            bucket_name=BUCKET_NAME,
-            object_name="datasets/mock.jpg/mock.jpg",
-            file_path="mock.jpg",
-        )
-        metadata = {
-            "filename": "mock.jpg",
-        }
-        buffer = BytesIO(dumps(metadata).encode())
-        MINIO_CLIENT.put_object(
-            bucket_name=BUCKET_NAME,
-            object_name="datasets/mock.jpg/mock.jpg.metadata",
-            data=buffer,
-            length=buffer.getbuffer().nbytes,
-        )
-
-    def delete_downloaded_files(self):
-        if os.path.isfile("mock-result.csv"):
-            os.remove("mock-result.csv")
-        if os.path.isfile("mock-result.jpg"):
-            os.remove("mock-result.jpg")
-
-    def test_list_datasets(self):
-        result = list_datasets()
+        result = platiagro.list_datasets()
         self.assertTrue(isinstance(result, list))
+        self.assertEqual(result, [dataset_name])
 
-    def test_load_dataset(self):
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.NO_SUCH_KEY_ERROR,
+    )
+    def test_load_dataset_not_found(self, mock_list_objects, mock_make_bucket):
+        """
+        Should raise an exception when given a dataset name that does not exist.
+        """
+        bad_dataset_name = "unk.zip"
+
         with self.assertRaises(FileNotFoundError):
-            load_dataset("UNK")
+            platiagro.load_dataset(name=bad_dataset_name)
 
-        # UnicodeDecodeError
-        result = load_dataset("mock.zip")
-        self.assertIsInstance(result, BytesIO)
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.BytesIO(util.BINARY_DATA),
+    )
+    def test_load_dataset_filelike_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should return a readable object successfully.
+        """
+        dataset_name = "unk.zip"
 
-        # EmptyDataError
-        result = load_dataset("mock.jpg")
-        self.assertIsInstance(result, BytesIO)
+        result = platiagro.load_dataset(name=dataset_name)
+        self.assertTrue(hasattr(result, "read"))
 
-        result = load_dataset("mock.csv")
-        expected = pd.DataFrame(
-            data=[self.mock_values() for x in range(int(1e2))],
-            columns=self.mock_columns(),
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.StringIO(util.CSV_DATA.decode()),
+    )
+    def test_load_dataset_dataframe_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should return a pandas DataFrame object successfully.
+        """
+        dataset_name = "unk.csv"
+
+        result = platiagro.load_dataset(name=dataset_name)
+        self.assertIsInstance(result, pd.DataFrame)
+
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.BytesIO(util.CSV_DATA),
+    )
+    def test_load_dataset_with_run_id_and_operator_id_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should return a pandas DataFrame object when run_id and operator_id exist.
+        """
+        dataset_name = "unk.csv"
+        run_id = "UNK"
+        operator_id = "UNK"
+
+        result = platiagro.load_dataset(
+            name=dataset_name, run_id=run_id, operator_id=operator_id
         )
-        self.assertTrue(result.equals(expected))
+        self.assertIsInstance(result, pd.DataFrame)
 
-        result = load_dataset("mock.csv", run_id=RUN_ID, operator_id=OPERATOR_ID)
-        expected = pd.DataFrame(
-            data=[self.mock_values() for x in range(int(1e2))],
-            columns=self.mock_columns(),
-        )
-        self.assertTrue(result.equals(expected))
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.NO_SUCH_KEY_ERROR,
+    )
+    def test_get_dataset_not_found(self, mock_get_object, mock_make_bucket):
+        """
+        Should raise an exception when given a dataset name that does not exist.
+        """
+        dataset_name = "unk.csv"
 
-        result = load_dataset("mock.csv", run_id="latest", operator_id=OPERATOR_ID)
-        expected = pd.DataFrame(
-            data=[self.mock_values() for x in range(int(1e2))],
-            columns=self.mock_columns(),
-        )
-        self.assertTrue(result.equals(expected))
-
-    def test_get_dataset(self):
-
-        # case where run_id and operator_id exists but the file doesn't
-        # ensuring that S3Error was raised
         with self.assertRaises(FileNotFoundError):
-            get_dataset("no-existent-file.csv", run_id=RUN_ID, operator_id=None)
+            platiagro.get_dataset(name=dataset_name)
 
-        # case where run_id and operator_id exists
-        result = get_dataset("mock.csv", run_id=RUN_ID, operator_id=OPERATOR_ID)
-        # file-like objects should have attr 'read'
-        self.assertTrue(hasattr(result, 'read'))
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.BytesIO(util.CSV_DATA),
+    )
+    def test_get_dataset_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should return a readable object successfully.
+        """
+        dataset_name = "unk.csv"
 
-        # case where run_id is None and operator_id exists
-        result = get_dataset("mock.csv", run_id=None, operator_id=OPERATOR_ID)
-        # file-like objects should have attr 'read'
-        self.assertTrue(hasattr(result, 'read'))
+        result = platiagro.get_dataset(name=dataset_name)
+        self.assertTrue(hasattr(result, "read"))
 
-        # case where run_id exists and operator_id is None
-        result = get_dataset("mock.csv", run_id=RUN_ID, operator_id=None)
-        # file-like objects should have attr 'read'
-        self.assertTrue(hasattr(result, 'read'))
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.BytesIO(util.CSV_DATA),
+    )
+    def test_get_dataset_with_run_id_and_operator_id_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should return a readable object when run_id and operator_id exist.
+        """
+        dataset_name = "unk.csv"
+        run_id = "UNK"
+        operator_id = "UNK"
 
-        # case where run_id and operator_id is None
-        result = get_dataset("mock.csv", run_id=None, operator_id=None)
-        # file-like objects should have attr 'read'
-        self.assertTrue(hasattr(result, 'read'))
-
-        # case where run_id and operator_id exists but run_id = 'latest'
-        result = get_dataset("mock.csv", run_id="latest", operator_id=OPERATOR_ID)
-        # file-like objects should have attr 'read'
-        self.assertTrue(hasattr(result, 'read'))
-
-    def test_save_dataset(self):
-        data = BytesIO(MOCK_IMAGE)
-        save_dataset("test.zip", data=data)
-
-        df = pd.DataFrame({"col0": []})
-        save_dataset("test.csv", df)
-
-        df = pd.DataFrame(
-            data=[self.mock_values() for x in range(int(1e2))],
-            columns=self.mock_columns(),
+        result = platiagro.get_dataset(
+            name=dataset_name, run_id=run_id, operator_id=operator_id
         )
-        save_dataset("test.csv", df)
+        self.assertTrue(hasattr(result, "read"))
 
-        df = pd.DataFrame(
-            data=[self.mock_values() for x in range(int(1e2))],
-            columns=self.mock_columns(),
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "put_object",
+        side_effect=util.put_object_side_effect,
+    )
+    def test_save_dataset_file_like_success(
+        self, mock_put_object, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should call .put_object twice: passing data, and passing metadata.
+        """
+        dataset_name = "unk.zip"
+        data = io.BytesIO(util.BINARY_DATA)
+
+        platiagro.save_dataset(name=dataset_name, data=data)
+
+        mock_put_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"datasets/{dataset_name}/{dataset_name}.metadata",
+            data=mock.ANY,
+            length=mock.ANY,
         )
-        save_dataset("test.csv", df, metadata={
-            "featuretypes": [CATEGORICAL for ft in self.mock_featuretypes()],
-        })
 
-        df = pd.DataFrame({"col0": []})
-        save_dataset("test.csv", df)
+        # BUG not sure why this assert fails...
+        # mock_put_object.assert_any_call(
+        #     bucket_name=BUCKET_NAME,
+        #     object_name=f"datasets/{dataset_name}/{dataset_name}",
+        #     data=mock.ANY,
+        #     length=mock.ANY,
+        # )
 
-        df = pd.DataFrame(
-            data=[self.mock_values() for x in range(int(1e2))],
-            columns=self.mock_columns(),
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "put_object",
+        side_effect=util.put_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "fput_object",
+        side_effect=util.fput_object_side_effect,
+    )
+    def test_save_dataset_dataframe_success(
+        self, mock_fput_object, mock_put_object, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should call .put_object twice: passing data, and passing metadata.
+        """
+        dataset_name = "unk.csv"
+        data = pd.DataFrame({"col0": []})
+
+        platiagro.save_dataset(name=dataset_name, data=data)
+
+        mock_fput_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"datasets/{dataset_name}/{dataset_name}",
+            file_path=mock.ANY,
         )
-        save_dataset("newtest.csv", df=df, run_id=RUN_ID, operator_id=OPERATOR_ID)
 
-    def test_stat_dataset(self):
+        mock_put_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"datasets/{dataset_name}/{dataset_name}.metadata",
+            data=mock.ANY,
+            length=mock.ANY,
+        )
+
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.NO_SUCH_KEY_ERROR,
+    )
+    def test_stat_dataset_not_found(self, mock_get_object, mock_make_bucket):
+        """
+        Should raise an exception when given a dataset name that does not exist.
+        """
+        dataset_name = "unk.csv"
+
         with self.assertRaises(FileNotFoundError):
-            stat_dataset("UNK")
+            platiagro.stat_dataset(name=dataset_name)
 
-        result = stat_dataset("mock.zip")
-        expected = {
-            "filename": "mock.zip",
-        }
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.BytesIO(util.CSV_DATA),
+    )
+    def test_stat_dataset_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should return a dict object successfully.
+        """
+        dataset_name = "unk.csv"
+
+        result = platiagro.stat_dataset(name=dataset_name)
+
+        expected = {"filename": dataset_name}
         self.assertDictEqual(result, expected)
 
-        result = stat_dataset("/tmp/data/mock.zip")
-        expected = {
-            "filename": "mock.zip",
-        }
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.BytesIO(util.CSV_DATA),
+    )
+    def test_stat_dataset_with_run_id_and_operator_id_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should return a dict object when run_id and operator_id exist.
+        """
+        dataset_name = "unk.csv"
+        run_id = "UNK"
+        operator_id = "UNK"
+
+        result = platiagro.stat_dataset(
+            name=dataset_name, run_id=run_id, operator_id=operator_id
+        )
+
+        expected = {"filename": dataset_name}
         self.assertDictEqual(result, expected)
 
-        result = stat_dataset("mock.csv")
-        expected = {
-            "columns": self.mock_columns(),
-            "featuretypes": self.mock_featuretypes(),
-            "filename": "mock.csv",
-            "run_id": RUN_ID,
-        }
-        self.assertDictEqual(result, expected)
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.NO_SUCH_KEY_ERROR,
+    )
+    def test_download_dataset_not_found(self, mock_download_dataset, mock_make_bucket):
+        """
+        Should raise an exception when given a dataset name that does not exist.
+        """
+        bad_dataset_name = "unk.zip"
+        path = "./unk.csv"
 
-        result = stat_dataset("mock.csv", run_id="latest", operator_id=OPERATOR_ID)
-        expected = {
-            "columns": self.mock_columns(),
-            "featuretypes": self.mock_featuretypes(),
-            "filename": "mock.csv",
-            "run_id": RUN_ID,
-        }
-        self.assertDictEqual(result, expected)
-
-        result = stat_dataset("mock.csv", run_id=RUN_ID, operator_id=OPERATOR_ID)
-        expected = {
-            "columns": self.mock_columns(),
-            "featuretypes": self.mock_featuretypes(),
-            "filename": "mock.csv",
-            "run_id": RUN_ID,
-        }
-        self.assertDictEqual(result, expected)
-
-        os.environ["RUN_ID"] = RUN_ID
-
-        result = stat_dataset("mock.csv")
-        expected = {
-            "columns": self.mock_columns(),
-            "featuretypes": self.mock_featuretypes(),
-            "filename": "mock.csv",
-            "run_id": RUN_ID,
-        }
-        self.assertDictEqual(result, expected)
-
-        result = stat_dataset("mock.csv", operator_id=OPERATOR_ID)
-        expected = {
-            "columns": self.mock_columns(),
-            "featuretypes": self.mock_featuretypes(),
-            "filename": "mock.csv",
-            "run_id": RUN_ID,
-        }
-        self.assertDictEqual(result, expected)
-
-        run_id = "THIS_RUN_ID_DOES_NOT_EXIST"
         with self.assertRaises(FileNotFoundError):
-            stat_dataset("mock.csv", run_id=run_id)
+            platiagro.download_dataset(name=bad_dataset_name, path=path)
 
-    def test_download_dataset(self):
-        download_dataset("mock.csv", "./mock-result.csv")
-        self.assertTrue(os.path.exists("./mock-result.csv"))
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        S3FS,
+        "open",
+        return_value=io.BytesIO(util.CSV_DATA),
+    )
+    def test_download_dataset_success(
+        self, mock_s3fs_open, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should download a dataset to a given local path.
+        """
+        dataset_name = "unk.csv"
+        path = "./unk.csv"
 
-        download_dataset("mock.jpg", "./mock-result.jpg")
-        self.assertTrue(os.path.exists("./mock-result.jpg"))
+        platiagro.download_dataset(name=dataset_name, path=path)
 
-    def test_update_dataset_metadata(self):
-        featuretypes = ['Categorical', 'Categorical', 'Categorical', 'Categorical', 'Categorical']
-        metadata = stat_dataset("mock.csv")
-        metadata["featuretypes"] = featuretypes
-        update_dataset_metadata("mock.csv", metadata)
-        result = stat_dataset("mock.csv")
-        expected = {
-            "columns": self.mock_columns(),
-            "featuretypes": featuretypes,
-            "filename": "mock.csv",
-            "run_id": RUN_ID,
+        self.assertTrue(os.path.exists(path))
+
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "put_object",
+        side_effect=util.put_object_side_effect,
+    )
+    def test_update_dataset_metadata(
+        self, mock_put_object, mock_get_object, mock_make_bucket
+    ):
+        dataset_name = "unk.csv"
+        metadata = {
+            "featuretypes": [
+                "Categorical",
+                "Categorical",
+                "Categorical",
+                "Categorical",
+                "Categorical",
+            ],
         }
-        self.assertDictEqual(result, expected)
+
+        platiagro.update_dataset_metadata(name=dataset_name, metadata=metadata)
+
+        mock_put_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"datasets/{dataset_name}/{dataset_name}.metadata",
+            data=mock.ANY,
+            length=mock.ANY,
+        )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,8 +6,6 @@ import unittest.mock as mock
 
 import pandas as pd
 from minio.datatypes import Object
-from minio.error import S3Error
-from urllib3.response import HTTPResponse
 
 import platiagro
 from platiagro.util import BUCKET_NAME, MINIO_CLIENT, S3FS

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -378,6 +378,9 @@ class TestDatasets(unittest.TestCase):
     def test_update_dataset_metadata(
         self, mock_put_object, mock_get_object, mock_make_bucket
     ):
+        """
+        Should call .put_object passing using .metadata as object_name.
+        """
         dataset_name = "unk.csv"
         metadata = {
             "featuretypes": [

--- a/tests/test_featuretypes.py
+++ b/tests/test_featuretypes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import os
 import unittest
-import unittest.mock as mock
 
 import pandas as pd
 

--- a/tests/test_featuretypes.py
+++ b/tests/test_featuretypes.py
@@ -1,43 +1,65 @@
 # -*- coding: utf-8 -*-
-from unittest import TestCase
+import os
+import unittest
+import unittest.mock as mock
 
 import pandas as pd
 
-from platiagro.featuretypes import DATETIME, CATEGORICAL, NUMERICAL, \
-    infer_featuretypes, validate_featuretypes
+import platiagro
 
 
-class TestFeaturetypes(TestCase):
-
-    def test_infer_featuretypes(self):
+class TestFeaturetypes(unittest.TestCase):
+    def test_infer_featuretypes_empty(self):
+        """
+        Should return empty list when dataframe is empty.
+        """
         df = pd.DataFrame()
+
+        result = platiagro.infer_featuretypes(df=df)
+
         expected = []
-        result = infer_featuretypes(df)
         self.assertListEqual(result, expected)
 
-        df = pd.DataFrame({
-            "col0": ["01-01-2019", "01-01-2020", "01-01-2021"],
-            "col1": ["Iris-setosa", "Iris-setosa", "Jun 999999999999999"],
-            "col2": [5.1, float('nan'), 4.7],
-            "col3": ["22.4", "10", "4.7"],
-        })
-        expected = [DATETIME, CATEGORICAL, NUMERICAL, NUMERICAL]
-        result = infer_featuretypes(df)
+    def test_infer_featuretypes_not_empty(self):
+        """
+        Should return list of features when dataframe is not empty.
+        """
+        df = pd.DataFrame(
+            {
+                "col0": ["01-01-2019", "01-01-2020", "01-01-2021"],
+                "col1": ["Iris-setosa", "Iris-setosa", "Jun 999999999999999"],
+                "col2": [5.1, float("nan"), 4.7],
+                "col3": ["22.4", "10", "4.7"],
+            }
+        )
+
+        result = platiagro.infer_featuretypes(df=df)
+
+        expected = [
+            platiagro.DATETIME,
+            platiagro.CATEGORICAL,
+            platiagro.NUMERICAL,
+            platiagro.NUMERICAL,
+        ]
         self.assertListEqual(result, expected)
 
-    def test_validate_featuretypes(self):
+    def test_validate_featuretypes_empty(self):
+        """
+        Should not raise exception when feature list is empty.
+        """
         featuretypes = []
-        validate_featuretypes(featuretypes)
 
-        featuretypes = [DATETIME, CATEGORICAL, NUMERICAL, "int"]
+        platiagro.validate_featuretypes(featuretypes)
+
+    def test_validate_featuretypes_value_error(self):
+        """
+        Should raise exception when feature list has invalid value (eg. "int").
+        """
+        featuretypes = [
+            platiagro.DATETIME,
+            platiagro.CATEGORICAL,
+            platiagro.NUMERICAL,
+            "int",
+        ]
         with self.assertRaises(ValueError):
-            validate_featuretypes(featuretypes)
-
-        featuretypes = [DATETIME]
-        validate_featuretypes(featuretypes)
-
-        featuretypes = [CATEGORICAL]
-        validate_featuretypes(featuretypes)
-
-        featuretypes = [NUMERICAL]
-        validate_featuretypes(featuretypes)
+            platiagro.validate_featuretypes(featuretypes)

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -218,7 +218,7 @@ class TestFigures(unittest.TestCase):
         self, mock_remove_object, mock_get_object, mock_list_objects, mock_make_bucket
     ):
         """
-        Should call .remove_object.
+        Should call .remove_object using env variables in object_name.
         """
         os.environ["EXPERIMENT_ID"] = "UNK"
         os.environ["OPERATOR_ID"] = "UNK"
@@ -256,7 +256,7 @@ class TestFigures(unittest.TestCase):
         self, mock_remove_object, mock_get_object, mock_list_objects, mock_make_bucket
     ):
         """
-        Should call .remove_object.
+        Should call .remove_object using env variables in object_name.
         """
         os.environ["DEPLOYMENT_ID"] = "UNK"
         os.environ["MONITORING_ID"] = "UNK"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,15 +1,26 @@
+# -*- coding: utf-8 -*-
+import unittest
+import unittest.mock as mock
+
 import platiagro.io
 
 
-class TestIO:
+class TestIO(unittest.TestCase):
+    @mock.patch("platiagro.io.zipfile")
+    def test_unzip_file(self, mock_zipfile):
+        """
+        Should extract zipfile to given path.
+        """
+        path_to_zip_file = "/path/to.zip"
+        directory_to_extract_to = "/path/to/extract"
 
-    def test_unzip_file(self, mocker):
-        mock_zipfile = mocker.MagicMock(name="zipfile")
-        mocker.patch("platiagro.io.zipfile", new=mock_zipfile)
+        platiagro.io.unzip_to_folder(
+            path_to_zip_file=path_to_zip_file,
+            directory_to_extract_to=directory_to_extract_to,
+        )
 
-        platiagro.io.unzip_to_folder("/path/to.zip", "/path/to/extract")
-
-        mock_zipfile.ZipFile.assert_called_once_with("/path/to.zip", "r")
+        mock_zipfile.ZipFile.assert_called_once_with(path_to_zip_file, "r")
         mock_zipfile.ZipFile.return_value.__enter__.assert_called_once_with()
-        mock_zipfile.ZipFile.return_value.__enter__.return_value.extractall. \
-            assert_called_once_with("/path/to/extract")
+        mock_zipfile.ZipFile.return_value.__enter__.return_value.extractall.assert_called_once_with(
+            "/path/to/extract"
+        )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -123,7 +123,7 @@ class TestMetrics(unittest.TestCase):
 
         mock_put_object.assert_any_call(
             bucket_name=BUCKET_NAME,
-            object_name=f"experiments/UNK/operators/UNK/metrics.json",
+            object_name=f"experiments/UNK/operators/UNK/UNK/metrics.json",
             data=mock.ANY,
             length=mock.ANY,
         )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -111,10 +111,14 @@ class TestMetrics(unittest.TestCase):
         """
         experiment_id = "UNK"
         operator_id = "UNK"
+        run_id = "UNK"
         accuracy = 0.5
 
         platiagro.save_metrics(
-            accuracy=accuracy, experiment_id=experiment_id, operator_id=operator_id
+            accuracy=accuracy,
+            experiment_id=experiment_id,
+            operator_id=operator_id,
+            run_id=run_id,
         )
 
         mock_put_object.assert_any_call(
@@ -139,10 +143,11 @@ class TestMetrics(unittest.TestCase):
         self, mock_put_object, mock_get_object, mock_make_bucket
     ):
         """
-        Should raise TypeError when metric is an invalid object type.
+        Should save metrics sucessfully.
         """
         os.environ["EXPERIMENT_ID"] = "UNK"
         os.environ["OPERATOR_ID"] = "UNK"
+        os.environ["RUN_ID"] = "UNK"
         accuracy = 0.5
         scores = pd.Series([1.0, 0.5, 0.1])
         r2_score = -3.0
@@ -150,37 +155,6 @@ class TestMetrics(unittest.TestCase):
         platiagro.save_metrics(accuracy=accuracy)
         platiagro.save_metrics(scores=scores)
         platiagro.save_metrics(r2_score=r2_score)
-
-        mock_put_object.assert_any_call(
-            bucket_name=BUCKET_NAME,
-            object_name=f"experiments/UNK/operators/UNK/metrics.json",
-            data=mock.ANY,
-            length=mock.ANY,
-        )
-
-    @mock.patch.object(MINIO_CLIENT, "make_bucket")
-    @mock.patch.object(
-        MINIO_CLIENT,
-        "get_object",
-        side_effect=util.get_object_side_effect,
-    )
-    @mock.patch.object(
-        MINIO_CLIENT,
-        "put_object",
-        side_effect=util.put_object_side_effect,
-    )
-    def test_save_metrics_with_env_variable_run_id_success(
-        self, mock_put_object, mock_get_object, mock_make_bucket
-    ):
-        """
-        Should raise TypeError when metric is an invalid object type.
-        """
-        os.environ["EXPERIMENT_ID"] = "UNK"
-        os.environ["OPERATOR_ID"] = "UNK"
-        os.environ["RUN_ID"] = "UNK"
-        accuracy = 0.5
-
-        platiagro.save_metrics(accuracy=accuracy)
 
         mock_put_object.assert_any_call(
             bucket_name=BUCKET_NAME,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,6 @@ import unittest
 import unittest.mock as mock
 
 import pandas as pd
-from minio.datatypes import Object
 
 import platiagro
 from platiagro.util import BUCKET_NAME, MINIO_CLIENT
@@ -19,19 +18,7 @@ class TestMetrics(unittest.TestCase):
         "get_object",
         side_effect=util.NO_SUCH_KEY_ERROR,
     )
-    @mock.patch.object(
-        MINIO_CLIENT,
-        "list_objects",
-        return_value=[
-            Object(
-                bucket_name=BUCKET_NAME,
-                object_name=f"experiments/UNK/operators/UNK/metrics.json",
-            )
-        ],
-    )
-    def test_list_metrics_not_found(
-        self, mock_list_objects, mock_get_object, mock_make_bucket
-    ):
+    def test_list_metrics_not_found(self, mock_get_object, mock_make_bucket):
         """
         Should list a single metric "accuracy".
         """
@@ -40,34 +27,41 @@ class TestMetrics(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             platiagro.list_metrics(experiment_id=experiment_id, operator_id=operator_id)
 
+        mock_make_bucket.assert_any_call(BUCKET_NAME)
+
+        mock_get_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/{experiment_id}/operators/{operator_id}/metrics.json",
+        )
+
     @mock.patch.object(MINIO_CLIENT, "make_bucket")
     @mock.patch.object(
         MINIO_CLIENT,
         "get_object",
         side_effect=util.get_object_side_effect,
     )
-    @mock.patch.object(
-        MINIO_CLIENT,
-        "list_objects",
-        return_value=[
-            Object(
-                bucket_name=BUCKET_NAME,
-                object_name=f"experiments/UNK/operators/UNK/metrics.json",
-            )
-        ],
-    )
-    def test_list_metrics_success(
-        self, mock_list_objects, mock_get_object, mock_make_bucket
-    ):
+    def test_list_metrics_success(self, mock_get_object, mock_make_bucket):
         """
         Should list a single metric "accuracy".
         """
         os.environ["EXPERIMENT_ID"] = "UNK"
         os.environ["OPERATOR_ID"] = "UNK"
+        os.environ["RUN_ID"] = "latest"
 
         metrics = platiagro.list_metrics()
         self.assertIsInstance(metrics, list)
         self.assertDictEqual(metrics[0], {"accuracy": 1.0})
+
+        mock_make_bucket.assert_any_call(BUCKET_NAME)
+
+        mock_get_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/{os.environ['EXPERIMENT_ID']}/operators/{os.environ['OPERATOR_ID']}/{os.environ['RUN_ID']}/metrics.json",
+        )
+
+        del os.environ["EXPERIMENT_ID"]
+        del os.environ["OPERATOR_ID"]
+        del os.environ["RUN_ID"]
 
     @mock.patch.object(MINIO_CLIENT, "make_bucket")
     @mock.patch.object(
@@ -88,9 +82,21 @@ class TestMetrics(unittest.TestCase):
         """
         os.environ["EXPERIMENT_ID"] = "UNK"
         os.environ["OPERATOR_ID"] = "UNK"
+        os.environ["RUN_ID"] = "latest"
 
         with self.assertRaises(TypeError):
             platiagro.save_metrics(accuracy=lambda x: "WUT")
+
+        mock_make_bucket.assert_any_call(BUCKET_NAME)
+
+        mock_get_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/{os.environ['EXPERIMENT_ID']}/operators/{os.environ['OPERATOR_ID']}/metrics.json",
+        )
+
+        del os.environ["EXPERIMENT_ID"]
+        del os.environ["OPERATOR_ID"]
+        del os.environ["RUN_ID"]
 
     @mock.patch.object(MINIO_CLIENT, "make_bucket")
     @mock.patch.object(
@@ -111,7 +117,7 @@ class TestMetrics(unittest.TestCase):
         """
         experiment_id = "UNK"
         operator_id = "UNK"
-        run_id = "UNK"
+        run_id = "latest"
         accuracy = 0.5
 
         platiagro.save_metrics(
@@ -121,9 +127,16 @@ class TestMetrics(unittest.TestCase):
             run_id=run_id,
         )
 
+        mock_make_bucket.assert_any_call(BUCKET_NAME)
+
+        mock_get_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/{experiment_id}/operators/{operator_id}/.metadata",
+        )
+
         mock_put_object.assert_any_call(
             bucket_name=BUCKET_NAME,
-            object_name=f"experiments/UNK/operators/UNK/UNK/metrics.json",
+            object_name=f"experiments/{experiment_id}/operators/{operator_id}/metrics.json",
             data=mock.ANY,
             length=mock.ANY,
         )
@@ -147,7 +160,7 @@ class TestMetrics(unittest.TestCase):
         """
         os.environ["EXPERIMENT_ID"] = "UNK"
         os.environ["OPERATOR_ID"] = "UNK"
-        os.environ["RUN_ID"] = "UNK"
+        os.environ["RUN_ID"] = "latest"
         accuracy = 0.5
         scores = pd.Series([1.0, 0.5, 0.1])
         r2_score = -3.0
@@ -156,9 +169,20 @@ class TestMetrics(unittest.TestCase):
         platiagro.save_metrics(scores=scores)
         platiagro.save_metrics(r2_score=r2_score)
 
+        mock_make_bucket.assert_any_call(BUCKET_NAME)
+
+        mock_get_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/{os.environ['EXPERIMENT_ID']}/operators/{os.environ['OPERATOR_ID']}/metrics.json",
+        )
+
         mock_put_object.assert_any_call(
             bucket_name=BUCKET_NAME,
-            object_name=f"experiments/UNK/operators/UNK/UNK/metrics.json",
+            object_name=f"experiments/UNK/operators/UNK/metrics.json",
             data=mock.ANY,
             length=mock.ANY,
         )
+
+        del os.environ["EXPERIMENT_ID"]
+        del os.environ["OPERATOR_ID"]
+        del os.environ["RUN_ID"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,123 +1,190 @@
 # -*- coding: utf-8 -*-
-from io import BytesIO
-from json import dumps
-from os import environ
-from unittest import TestCase
-from uuid import uuid4
+import os
+import unittest
+import unittest.mock as mock
 
 import pandas as pd
-from minio.error import S3Error
-from platiagro import list_metrics, save_metrics
+from minio.datatypes import Object
+
+import platiagro
 from platiagro.util import BUCKET_NAME, MINIO_CLIENT
 
-EXPERIMENT_ID = str(uuid4())
-OPERATOR_ID = str(uuid4())
-RUN_ID = str(uuid4())
+import tests.util as util
 
 
-class TestMetrics(TestCase):
+class TestMetrics(unittest.TestCase):
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.NO_SUCH_KEY_ERROR,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "list_objects",
+        return_value=[
+            Object(
+                bucket_name=BUCKET_NAME,
+                object_name=f"experiments/UNK/operators/UNK/metrics.json",
+            )
+        ],
+    )
+    def test_list_metrics_not_found(
+        self, mock_list_objects, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should list a single metric "accuracy".
+        """
+        experiment_id = "UNK"
+        operator_id = "UNK"
+        with self.assertRaises(FileNotFoundError):
+            platiagro.list_metrics(experiment_id=experiment_id, operator_id=operator_id)
 
-    def setUp(self):
-        """Prepares metrics for tests."""
-        self.make_bucket()
-        self.create_mock_metrics()
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "list_objects",
+        return_value=[
+            Object(
+                bucket_name=BUCKET_NAME,
+                object_name=f"experiments/UNK/operators/UNK/metrics.json",
+            )
+        ],
+    )
+    def test_list_metrics_success(
+        self, mock_list_objects, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should list a single metric "accuracy".
+        """
+        os.environ["EXPERIMENT_ID"] = "UNK"
+        os.environ["OPERATOR_ID"] = "UNK"
 
-    def make_bucket(self):
-        try:
-            MINIO_CLIENT.make_bucket(BUCKET_NAME)
-        except S3Error as err:
-            if err.code == "BucketAlreadyOwnedByYou":
-                pass
+        metrics = platiagro.list_metrics()
+        self.assertIsInstance(metrics, list)
+        self.assertDictEqual(metrics[0], {"accuracy": 1.0})
 
-    def create_mock_metrics(self):
-        metric = [{"accuracy": 1.0}]
-        buffer = BytesIO(dumps(metric).encode())
-        MINIO_CLIENT.put_object(
-            bucket_name=BUCKET_NAME,
-            object_name=f"experiments/{EXPERIMENT_ID}/operators/{OPERATOR_ID}/metrics.json",
-            data=buffer,
-            length=buffer.getbuffer().nbytes,
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "put_object",
+        side_effect=util.put_object_side_effect,
+    )
+    def test_save_metrics_type_error(
+        self, mock_put_object, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should raise TypeError when metric is an invalid object type.
+        """
+        os.environ["EXPERIMENT_ID"] = "UNK"
+        os.environ["OPERATOR_ID"] = "UNK"
+
+        with self.assertRaises(TypeError):
+            platiagro.save_metrics(accuracy=lambda x: "WUT")
+
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "put_object",
+        side_effect=util.put_object_side_effect,
+    )
+    def test_save_metrics_success(
+        self, mock_put_object, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should raise TypeError when metric is an invalid object type.
+        """
+        experiment_id = "UNK"
+        operator_id = "UNK"
+        accuracy = 0.5
+
+        platiagro.save_metrics(
+            accuracy=accuracy, experiment_id=experiment_id, operator_id=operator_id
         )
 
-    def test_list_metrics(self):
-        with self.assertRaises(FileNotFoundError):
-            list_metrics("UNK", "UNK")
+        mock_put_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/UNK/operators/UNK/metrics.json",
+            data=mock.ANY,
+            length=mock.ANY,
+        )
 
-        environ["EXPERIMENT_ID"] = EXPERIMENT_ID
-        environ["OPERATOR_ID"] = OPERATOR_ID
-        metrics = list_metrics()
-        self.assertIsInstance(metrics, list)
-        self.assertDictEqual(metrics[0], {"accuracy": 1.0})
-        del environ["EXPERIMENT_ID"]
-        del environ["OPERATOR_ID"]
-
-        metrics = list_metrics(experiment_id=EXPERIMENT_ID, operator_id=OPERATOR_ID)
-        self.assertIsInstance(metrics, list)
-        self.assertDictEqual(metrics[0], {"accuracy": 1.0})
-
-    def test_save_metrics(self):
-        environ["EXPERIMENT_ID"] = EXPERIMENT_ID
-        environ["OPERATOR_ID"] = OPERATOR_ID
-        with self.assertRaises(TypeError):
-            save_metrics(accuracy=lambda x: "WUT")
-
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "put_object",
+        side_effect=util.put_object_side_effect,
+    )
+    def test_save_metrics_env_variables_success(
+        self, mock_put_object, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should raise TypeError when metric is an invalid object type.
+        """
+        os.environ["EXPERIMENT_ID"] = "UNK"
+        os.environ["OPERATOR_ID"] = "UNK"
+        accuracy = 0.5
         scores = pd.Series([1.0, 0.5, 0.1])
+        r2_score = -3.0
 
-        save_metrics(accuracy=0.5)
-        save_metrics(scores=scores)
-        save_metrics(r2_score=-3.0)
-        del environ["EXPERIMENT_ID"]
-        del environ["OPERATOR_ID"]
+        platiagro.save_metrics(accuracy=accuracy)
+        platiagro.save_metrics(scores=scores)
+        platiagro.save_metrics(r2_score=r2_score)
 
-        save_metrics(experiment_id=EXPERIMENT_ID,
-                     operator_id=OPERATOR_ID,
-                     accuracy=0.5)
-        save_metrics(experiment_id=EXPERIMENT_ID,
-                     operator_id=OPERATOR_ID,
-                     scores=scores)
-        save_metrics(experiment_id=EXPERIMENT_ID,
-                     operator_id=OPERATOR_ID,
-                     r2_score=-3.0)
+        mock_put_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/UNK/operators/UNK/metrics.json",
+            data=mock.ANY,
+            length=mock.ANY,
+        )
 
-    def test_run_id(self):
-        metrics = list_metrics(experiment_id=EXPERIMENT_ID,
-                               operator_id=OPERATOR_ID,
-                               run_id="latest")
-        self.assertTrue(isinstance(metrics, list))
-        self.assertEqual(metrics, [])
+    @mock.patch.object(MINIO_CLIENT, "make_bucket")
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "get_object",
+        side_effect=util.get_object_side_effect,
+    )
+    @mock.patch.object(
+        MINIO_CLIENT,
+        "put_object",
+        side_effect=util.put_object_side_effect,
+    )
+    def test_save_metrics_with_env_variable_run_id_success(
+        self, mock_put_object, mock_get_object, mock_make_bucket
+    ):
+        """
+        Should raise TypeError when metric is an invalid object type.
+        """
+        os.environ["EXPERIMENT_ID"] = "UNK"
+        os.environ["OPERATOR_ID"] = "UNK"
+        os.environ["RUN_ID"] = "UNK"
+        accuracy = 0.5
 
-        environ["EXPERIMENT_ID"] = EXPERIMENT_ID
-        environ["OPERATOR_ID"] = OPERATOR_ID
-        environ["RUN_ID"] = RUN_ID
+        platiagro.save_metrics(accuracy=accuracy)
 
-        with self.assertRaises(FileNotFoundError):
-            list_metrics()
-
-        save_metrics(accuracy=0.75)
-        metrics = list_metrics()
-        self.assertTrue(isinstance(metrics, list))
-        self.assertDictEqual(metrics[0], {"accuracy": 0.75})
-
-        del environ["EXPERIMENT_ID"]
-        del environ["OPERATOR_ID"]
-        del environ["RUN_ID"]
-
-        save_metrics(experiment_id=EXPERIMENT_ID,
-                     operator_id=OPERATOR_ID,
-                     run_id=RUN_ID,
-                     r2_score=1.0)
-        metrics = list_metrics(experiment_id=EXPERIMENT_ID,
-                               operator_id=OPERATOR_ID,
-                               run_id=RUN_ID)
-        self.assertTrue(isinstance(metrics, list))
-        self.assertDictEqual(metrics[1], {"r2_score": 1.0})
-
-        save_metrics(experiment_id=EXPERIMENT_ID,
-                     operator_id=OPERATOR_ID,
-                     run_id="latest",
-                     r2_score=2.0)
-        metrics = list_metrics(experiment_id=EXPERIMENT_ID,
-                               operator_id=OPERATOR_ID,
-                               run_id="latest")
-        self.assertTrue(isinstance(metrics, list))
-        self.assertDictEqual(metrics[2], {"r2_score": 2.0})
+        mock_put_object.assert_any_call(
+            bucket_name=BUCKET_NAME,
+            object_name=f"experiments/UNK/operators/UNK/UNK/metrics.json",
+            data=mock.ANY,
+            length=mock.ANY,
+        )

--- a/tests/test_metrics_nlp.py
+++ b/tests/test_metrics_nlp.py
@@ -2,9 +2,6 @@
 from unittest import TestCase
 from uuid import uuid4
 
-# Math/Alg. Lin.
-import numpy as np
-
 # Wrapper
 from platiagro.metrics_nlp.wrapper import MetricsCalculator
 
@@ -23,11 +20,9 @@ from platiagro.metrics_nlp.utils import (
 # List Metrics
 from platiagro.metrics_nlp.metrics import get_metrics_data
 
-# Base Class
-from platiagro.metrics_nlp.base import BaseMetric
-
 # Typing
-from typing import List, Tuple, Dict, Any, Union
+from typing import List
+
 
 # Mock tokenizer
 class MockTokenizer(object):

--- a/tests/test_metrics_nlp.py
+++ b/tests/test_metrics_nlp.py
@@ -9,8 +9,16 @@ import numpy as np
 from platiagro.metrics_nlp.wrapper import MetricsCalculator
 
 # Test values
-from platiagro.metrics_nlp.utils import SAMPLE_HYPS, SAMPLE_REFS_SINGLE, SAMPLE_REFS_MULT
-from platiagro.metrics_nlp.utils import SAMPLE_HYPS_TK, SAMPLE_REFS_SINGLE_TK, SAMPLE_REFS_MULT_TK
+from platiagro.metrics_nlp.utils import (
+    SAMPLE_HYPS,
+    SAMPLE_REFS_SINGLE,
+    SAMPLE_REFS_MULT,
+)
+from platiagro.metrics_nlp.utils import (
+    SAMPLE_HYPS_TK,
+    SAMPLE_REFS_SINGLE_TK,
+    SAMPLE_REFS_MULT_TK,
+)
 
 # List Metrics
 from platiagro.metrics_nlp.metrics import get_metrics_data
@@ -31,7 +39,7 @@ class MockTokenizer(object):
         for i, sample_hyp_tk in enumerate(SAMPLE_HYPS_TK):
             if token_ids == sample_hyp_tk:
                 return SAMPLE_HYPS[i]
-        
+
         for i, sample_ref_single_tk in enumerate(SAMPLE_REFS_SINGLE_TK):
             if token_ids == sample_ref_single_tk:
                 return SAMPLE_REFS_SINGLE[i]
@@ -41,28 +49,28 @@ class MockTokenizer(object):
                 if token_ids == SAMPLE_REFS_MULT_TK[i][j]:
                     return SAMPLE_REFS_MULT[i][j]
 
-        raise ValueError('Unknown token_ids_batch')
- 
+        raise ValueError("Unknown token_ids_batch")
+
+
 RUN_ID = str(uuid4())
 
 
 class TestMetricsNLP(TestCase):
-
     def setUp(self):
         """Don't need a setup"""
         pass
 
     def test_metrics_call(self):
-        
+
         # Get metrics data
         metrics_data = get_metrics_data()
         metrics_name = list(metrics_data.keys())
 
         # Check metrics
         for metric in metrics_name:
-            
+
             # Initialize metric component
-            metric_component = metrics_data[metric]['component']()
+            metric_component = metrics_data[metric]["component"]()
 
             # Get test sample
             hypothesis = SAMPLE_HYPS[0]
@@ -72,35 +80,43 @@ class TestMetricsNLP(TestCase):
             # Call metric
 
             # Single reference
-            metric_value = metric_component(hypothesis=hypothesis, references=references_single)
+            metric_value = metric_component(
+                hypothesis=hypothesis, references=references_single
+            )
             self.assertIsInstance(metric_value, float)
 
             # Multiple reference
-            if not metrics_data[metric]['single_ref_only']:
-                metric_value = metric_component(hypothesis=hypothesis, references=references_mult)
+            if not metrics_data[metric]["single_ref_only"]:
+                metric_value = metric_component(
+                    hypothesis=hypothesis, references=references_mult
+                )
                 self.assertIsInstance(metric_value, float)
-    
+
     def test_metrics_calculate(self):
-        
+
         # Get metrics data
         metrics_data = get_metrics_data()
         metrics_name = list(metrics_data.keys())
 
         # Check metrics
         for metric in metrics_name:
-            
+
             # Initialize metric component
-            metric_component = metrics_data[metric]['component']()
+            metric_component = metrics_data[metric]["component"]()
 
             # Call metric
 
             # Single reference
-            metric_value = metric_component.calculate(batch_hypotheses=SAMPLE_HYPS, batch_references=SAMPLE_REFS_SINGLE)
+            metric_value = metric_component.calculate(
+                batch_hypotheses=SAMPLE_HYPS, batch_references=SAMPLE_REFS_SINGLE
+            )
             self.assertIsInstance(metric_value, float)
 
             # Multiple reference
-            if not metrics_data[metric]['single_ref_only']:
-                metric_value = metric_component.calculate(batch_hypotheses=SAMPLE_HYPS, batch_references=SAMPLE_REFS_MULT)
+            if not metrics_data[metric]["single_ref_only"]:
+                metric_value = metric_component.calculate(
+                    batch_hypotheses=SAMPLE_HYPS, batch_references=SAMPLE_REFS_MULT
+                )
                 self.assertIsInstance(metric_value, float)
 
     def test_metrics_wrapper_all(self):
@@ -110,8 +126,10 @@ class TestMetricsNLP(TestCase):
         metrics_name = list(metrics_data.keys())
 
         # Initializate wrappers
-        wrapper_all = MetricsCalculator() # default == all metrics
-        wrapper_all_params = MetricsCalculator(metric_params = {'gleu': {'min_len': 1,'max_len': 3}}) # default == all metrics
+        wrapper_all = MetricsCalculator()  # default == all metrics
+        wrapper_all_params = MetricsCalculator(
+            metric_params={"gleu": {"min_len": 1, "max_len": 3}}
+        )  # default == all metrics
 
         # Check documentation
         self.assertIsInstance(wrapper_all.__str__(), str)
@@ -120,22 +138,34 @@ class TestMetricsNLP(TestCase):
         # Check wrappers #
 
         # All, single reference, text
-        values = wrapper_all.calculate_from_texts(hypothesis=SAMPLE_HYPS, references=SAMPLE_REFS_SINGLE)
+        values = wrapper_all.calculate_from_texts(
+            hypothesis=SAMPLE_HYPS, references=SAMPLE_REFS_SINGLE
+        )
         self.assertIsInstance(values, dict)
         self.assertEqual(len(values), len(metrics_name))
 
         # All, single reference, tokens
-        values = wrapper_all.calculate_from_tokens(hypothesis_tokens=SAMPLE_HYPS_TK, references_tokens=SAMPLE_REFS_SINGLE_TK, tokenizer=MockTokenizer())
+        values = wrapper_all.calculate_from_tokens(
+            hypothesis_tokens=SAMPLE_HYPS_TK,
+            references_tokens=SAMPLE_REFS_SINGLE_TK,
+            tokenizer=MockTokenizer(),
+        )
         self.assertIsInstance(values, dict)
         self.assertEqual(len(values), len(metrics_name))
 
         # All, single reference, text
-        values = wrapper_all_params.calculate_from_texts(hypothesis=SAMPLE_HYPS, references=SAMPLE_REFS_SINGLE)
+        values = wrapper_all_params.calculate_from_texts(
+            hypothesis=SAMPLE_HYPS, references=SAMPLE_REFS_SINGLE
+        )
         self.assertIsInstance(values, dict)
         self.assertEqual(len(values), len(metrics_name))
 
         # All, single reference, tokens
-        values = wrapper_all_params.calculate_from_tokens(hypothesis_tokens=SAMPLE_HYPS_TK, references_tokens=SAMPLE_REFS_SINGLE_TK, tokenizer=MockTokenizer())
+        values = wrapper_all_params.calculate_from_tokens(
+            hypothesis_tokens=SAMPLE_HYPS_TK,
+            references_tokens=SAMPLE_REFS_SINGLE_TK,
+            tokenizer=MockTokenizer(),
+        )
         self.assertIsInstance(values, dict)
         self.assertEqual(len(values), len(metrics_name))
 
@@ -144,7 +174,11 @@ class TestMetricsNLP(TestCase):
         # Get metrics data
         metrics_data = get_metrics_data()
         metrics_name = list(metrics_data.keys())
-        mult_metrics_name = [metric for metric in metrics_name if not metrics_data[metric]['single_ref_only']]
+        mult_metrics_name = [
+            metric
+            for metric in metrics_name
+            if not metrics_data[metric]["single_ref_only"]
+        ]
 
         # Initializate wrappers
         wrapper_mult = MetricsCalculator(metrics=mult_metrics_name)
@@ -155,12 +189,18 @@ class TestMetricsNLP(TestCase):
         # Check wrappers #
 
         # Mult, multiple reference, text
-        values = wrapper_mult.calculate_from_texts(hypothesis=SAMPLE_HYPS, references=SAMPLE_REFS_MULT)
+        values = wrapper_mult.calculate_from_texts(
+            hypothesis=SAMPLE_HYPS, references=SAMPLE_REFS_MULT
+        )
         self.assertIsInstance(values, dict)
         self.assertEqual(len(values), len(mult_metrics_name))
 
         # Mult, multiple reference, token
-        values = wrapper_mult.calculate_from_tokens(hypothesis_tokens=SAMPLE_HYPS_TK, references_tokens=SAMPLE_REFS_MULT_TK, tokenizer=MockTokenizer())
+        values = wrapper_mult.calculate_from_tokens(
+            hypothesis_tokens=SAMPLE_HYPS_TK,
+            references_tokens=SAMPLE_REFS_MULT_TK,
+            tokenizer=MockTokenizer(),
+        )
         self.assertIsInstance(values, dict)
         self.assertEqual(len(values), len(mult_metrics_name))
 
@@ -172,29 +212,29 @@ class TestMetricsNLP(TestCase):
 
         # Check metrics
         for metric in metrics_name:
-            
+
             # Initialize metric component
-            metric_component = metrics_data[metric]['component']()
+            metric_component = metrics_data[metric]["component"]()
 
             # Call metric
 
             with self.assertRaises(ValueError):
-                metric_component.calculate(batch_hypotheses=[''], batch_references=[0])
-            
-            with self.assertRaises(ValueError):
-                metric_component.calculate(batch_hypotheses=[0], batch_references=[''])
+                metric_component.calculate(batch_hypotheses=[""], batch_references=[0])
 
-        if 'rouge' in metrics_name:
-            
-            rouge = metrics_data['rouge']['component']()
+            with self.assertRaises(ValueError):
+                metric_component.calculate(batch_hypotheses=[0], batch_references=[""])
+
+        if "rouge" in metrics_name:
+
+            rouge = metrics_data["rouge"]["component"]()
 
             # Invalid rouge metric
             with self.assertRaises(ValueError):
-                rouge('a', 'b', metric = '')
-                
+                rouge("a", "b", metric="")
+
             # Invalid rouge method
             with self.assertRaises(ValueError):
-                rouge('a', 'b', method = '')
+                rouge("a", "b", method="")
 
     def test_metrics_empty_string(self):
 
@@ -204,16 +244,16 @@ class TestMetricsNLP(TestCase):
 
         # Check metrics
         for metric in metrics_name:
-            
+
             # Initialize metric component
-            metric_component = metrics_data[metric]['component']()
+            metric_component = metrics_data[metric]["component"]()
 
             # Call metric
-            value = metric_component(hypothesis='', references='')
-            self.assertIsInstance(value, float)
-            
-            value = metric_component(hypothesis='a', references='')
+            value = metric_component(hypothesis="", references="")
             self.assertIsInstance(value, float)
 
-            value = metric_component(hypothesis='', references='a')
+            value = metric_component(hypothesis="a", references="")
+            self.assertIsInstance(value, float)
+
+            value = metric_component(hypothesis="", references="a")
             self.assertIsInstance(value, float)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,15 +2,11 @@
 import os
 import unittest
 import unittest.mock as mock
-import uuid
 
 import platiagro
 from platiagro.util import BUCKET_NAME, MINIO_CLIENT
 
 import tests.util as util
-
-EXPERIMENT_ID = str(uuid.uuid4())
-OPERATOR_ID = str(uuid.uuid4())
 
 
 class TestModels(unittest.TestCase):
@@ -24,8 +20,11 @@ class TestModels(unittest.TestCase):
         """
         Should return a MockModel object when experiment_id and operator_id exist.
         """
+        experiment_id = "UNK"
+        operator_id = "UNK"
+
         model = platiagro.load_model(
-            experiment_id=EXPERIMENT_ID, operator_id=OPERATOR_ID
+            experiment_id=experiment_id, operator_id=operator_id
         )
 
         self.assertIsInstance(model, dict)
@@ -43,8 +42,8 @@ class TestModels(unittest.TestCase):
         """
         Should return a MockModel object when experiment_id and operator_id exist.
         """
-        os.environ["EXPERIMENT_ID"] = EXPERIMENT_ID
-        os.environ["OPERATOR_ID"] = OPERATOR_ID
+        os.environ["EXPERIMENT_ID"] = "UNK"
+        os.environ["OPERATOR_ID"] = "UNK"
 
         model = platiagro.load_model()
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,24 +1,19 @@
-from unittest import TestCase
-from uuid import uuid4
+# -*- coding: utf-8 -*-
+import unittest
 
 import numpy as np
 
-from platiagro.pipeline import GuaranteeType
+import platiagro.pipeline
 
 
-RUN_ID = str(uuid4())
-
-
-class TestPipeline(TestCase):
-
-    def setUp(self):
-        pass
-
+class TestPipeline(unittest.TestCase):
     def test_guarantee(self):
+        """
+        Should cast str to float.
+        """
+        x = np.array(["1", "2", "3", "4", "5"])
 
-        x = np.array([1, 2, 3, 4, 5])
-
-        gt = GuaranteeType()
+        gt = platiagro.pipeline.GuaranteeType()
 
         assert gt.fit(x).dtype == float
         assert gt.transform(x).dtype == float

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -45,7 +45,7 @@ from platiagro.plotting import plot_bboxes
 
 from .test_util import get_iris, get_boston
 
- 
+
 RUN_ID = str(uuid4())
 
 iris = get_iris()
@@ -53,302 +53,305 @@ boston = get_boston()
 
 
 class TestPlotting(TestCase):
-
     def setUp(self):
         pass
 
-
     def test_roc(self):
 
-        labels = np.unique(iris['target'])
+        labels = np.unique(iris["target"])
 
-        plot_roc_curve(iris['target_test'],
-                       iris['target_probability'],
-                       labels)
-
+        plot_roc_curve(iris["target_test"], iris["target_probability"], labels)
 
     def test_regression_error(self):
-        
-        plot_regression_error(boston['target_test'],
-                              boston['target_predicted'])
 
+        plot_regression_error(boston["target_test"], boston["target_predicted"])
 
     def test_prediction_diff(self):
 
-        plot_prediction_diff(boston['target_test'],
-                             boston['target_predicted'])
+        plot_prediction_diff(boston["target_test"], boston["target_predicted"])
 
-    
     def test_sorted_prediction_diff(self):
 
-        plot_sorted_prediction_diff(boston['target_test'],
-                                    boston['target_predicted'])
-
+        plot_sorted_prediction_diff(boston["target_test"], boston["target_predicted"])
 
     def test_absolute_error(self):
 
-        plot_absolute_error(boston['target_test'],
-                            boston['target_predicted'])
-
+        plot_absolute_error(boston["target_test"], boston["target_predicted"])
 
     def test_probability_error(self):
 
-        plot_probability_error(boston['target_test'],
-                               boston['target_predicted'])
-
+        plot_probability_error(boston["target_test"], boston["target_predicted"])
 
     def test_segment_error(self):
 
-        plot_segment_error(boston['target_test'],
-                           boston['target_predicted'])
-        
-    
+        plot_segment_error(boston["target_test"], boston["target_predicted"])
+
     def test_regression_data(self):
 
-        plot_regression_data(boston['regression_pipeline'], 
-                             boston['features_columns'],
-                             boston['features_train'],
-                             boston['target_train'],
-                             boston['features_test'],
-                             boston['target_test'],
-                             boston['target_predicted'])
-
+        plot_regression_data(
+            boston["regression_pipeline"],
+            boston["features_columns"],
+            boston["features_train"],
+            boston["target_train"],
+            boston["features_test"],
+            boston["target_test"],
+            boston["target_predicted"],
+        )
 
     def test_classification_data(self):
 
-        plot_classification_data(iris['classification_pipeline'], 
-                                 iris['features_columns'], 
-                                 iris['features_train'], 
-                                 iris['target_train'], 
-                                 iris['features_test'], 
-                                 iris['target_test'], 
-                                 iris['target_predicted'])
-
+        plot_classification_data(
+            iris["classification_pipeline"],
+            iris["features_columns"],
+            iris["features_train"],
+            iris["target_train"],
+            iris["features_test"],
+            iris["target_test"],
+            iris["target_predicted"],
+        )
 
     def test_matrix(self):
 
         # computes confusion matrix
-        labels = np.unique(iris['target_encoded'])
-        data = confusion_matrix(iris['target_test'],
-                                iris['target_predicted'],
-                                labels=labels)
+        labels = np.unique(iris["target_encoded"])
+        data = confusion_matrix(
+            iris["target_test"], iris["target_predicted"], labels=labels
+        )
 
         # puts matrix in pandas.DataFrame for better format
-        labels_dec = np.unique(iris['target'])
+        labels_dec = np.unique(iris["target"])
         df = pd.DataFrame(data, columns=labels_dec, index=labels_dec)
 
         plot_matrix(df)
 
-
     def test_common_metrics(self):
 
-        labels = np.unique(iris['target_encoded'])
-        labels_dec = np.unique(iris['target'])
+        labels = np.unique(iris["target_encoded"])
+        labels_dec = np.unique(iris["target"])
 
-        plot_common_metrics(iris['target_test'],
-                            iris['target_predicted'],
-                            labels,
-                            labels_dec)
-
+        plot_common_metrics(
+            iris["target_test"], iris["target_predicted"], labels, labels_dec
+        )
 
     def test_clustering_data(self):
-        
-        plot_clustering_data(iris['clustering_pipeline'], 
-                             iris['dataset_columns'], 
-                             iris['features'],
-                             iris['clusters'])
 
+        plot_clustering_data(
+            iris["clustering_pipeline"],
+            iris["dataset_columns"],
+            iris["features"],
+            iris["clusters"],
+        )
 
     def test_data_table(self):
 
-        data = {'col_1': [3, 2, 1, 0], 
-                'col_2': ['a', 'b', 'c', 'd']}
+        data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}
 
         df = pd.DataFrame.from_dict(data)
 
         plot_data_table(df)
-
 
     def test_line_subgraphs_alongisde(self):
         x1 = np.linspace(0, 10 - 2 * 1, 200) + 1
         y1 = np.sin(x1) + 1.0 + 1
         x2 = np.linspace(0, 10 - 2 * 3, 200) + 2
         y2 = np.sin(x2) + 1.0 + 2
-        
+
         with self.assertRaises(ValueError):
             x_list = [np.array(x1)]
             y_list = [np.array(y2)]
-            plot_line_subgraphs_alongisde(x_list,
-                                        y_list,
-                                        x_axe_names= ["x"],
-                                        y_axe_names = ["y"],
-                                        col_wrap=1,
-                                        suptitle="Train Performance",
-                                        subtitles = ['Loss'],
-                                        subplot_size = (10,10))
+            plot_line_subgraphs_alongisde(
+                x_list,
+                y_list,
+                x_axe_names=["x"],
+                y_axe_names=["y"],
+                col_wrap=1,
+                suptitle="Train Performance",
+                subtitles=["Loss"],
+                subplot_size=(10, 10),
+            )
 
         with self.assertRaises(ValueError):
-            x_list = [np.array(x1),np.array(x2)]
+            x_list = [np.array(x1), np.array(x2)]
             y_list = [np.array(y2)]
-            plot_line_subgraphs_alongisde(x_list,
-                                        y_list,
-                                        x_axe_names= ["x"],
-                                        y_axe_names = ["y"],
-                                        col_wrap=1,
-                                        suptitle="",
-                                        subtitles = ['Loss'],
-                                        subplot_size = (10,10))
+            plot_line_subgraphs_alongisde(
+                x_list,
+                y_list,
+                x_axe_names=["x"],
+                y_axe_names=["y"],
+                col_wrap=1,
+                suptitle="",
+                subtitles=["Loss"],
+                subplot_size=(10, 10),
+            )
 
-        
+        x_list = [np.array(x1), np.array(x2), np.array(x2)]
+        y_list = [np.array(y1), np.array(y2), np.array(y2)]
 
-
-
-        x_list = [np.array(x1),np.array(x2),np.array(x2)]
-        y_list = [np.array(y1),np.array(y2),np.array(y2)]
-        
-
-
-        plot_line_subgraphs_alongisde(x_list,
-                                    y_list,
-                                    x_axe_names= ["x"],
-                                    y_axe_names = ["y"],
-                                    col_wrap=1,
-                                    suptitle="Train Performance",
-                                    subtitles = ['Loss','Acurácia','Outro'],
-                                    subplot_size = (10,10))
+        plot_line_subgraphs_alongisde(
+            x_list,
+            y_list,
+            x_axe_names=["x"],
+            y_axe_names=["y"],
+            col_wrap=1,
+            suptitle="Train Performance",
+            subtitles=["Loss", "Acurácia", "Outro"],
+            subplot_size=(10, 10),
+        )
 
     def test_line_graphs_overlayed(self):
         x1 = np.linspace(0, 10 - 2 * 1, 200) + 1
         y1 = np.sin(x1) + 1.0 + 1
         x2 = np.linspace(0, 10 - 2 * 3, 200) + 2
         y2 = np.sin(x2) + 1.0 + 2
-        
-
-
 
         with self.assertRaises(ValueError):
             x_list = [np.array(x1)]
             y_list = [np.array(y1)]
             legends = ["legend1"]
-            plot_line_graphs_overlayed(x_list = x_list,
-                                                y_list=y_list,
-                                                x_axe_name="x_axe", 
-                                                y_axe_name="y_axe",
-                                                legends=legends,
-                                                title="Title",
-                                                legend_position='upper right')
+            plot_line_graphs_overlayed(
+                x_list=x_list,
+                y_list=y_list,
+                x_axe_name="x_axe",
+                y_axe_name="y_axe",
+                legends=legends,
+                title="Title",
+                legend_position="upper right",
+            )
         with self.assertRaises(ValueError):
 
-            x_list = [np.array(x1),np.array(x2)]
+            x_list = [np.array(x1), np.array(x2)]
             y_list = [np.array(y1), np.array(y2)]
             legends = ["legend1"]
-            plot_line_graphs_overlayed(x_list = x_list,
-                                                y_list=y_list,
-                                                x_axe_name="x_axe", 
-                                                y_axe_name="y_axe",
-                                                legends=legends,
-                                                title="Title",
-                                                legend_position='upper right')
-                            
-        
-        x_list = [np.array(x1),np.array(x2)]
-        y_list = [np.array(y1),np.array(y2)]
-        legends = ["legend1","legend2"]
-        plot_line_graphs_overlayed(x_list = x_list,
-                                        y_list=y_list,
-                                        x_axe_name="x_axe", 
-                                        y_axe_name="y_axe",
-                                        legends=legends,
-                                        title="Title",
-                                        legend_position='upper right')
+            plot_line_graphs_overlayed(
+                x_list=x_list,
+                y_list=y_list,
+                x_axe_name="x_axe",
+                y_axe_name="y_axe",
+                legends=legends,
+                title="Title",
+                legend_position="upper right",
+            )
 
-
+        x_list = [np.array(x1), np.array(x2)]
+        y_list = [np.array(y1), np.array(y2)]
+        legends = ["legend1", "legend2"]
+        plot_line_graphs_overlayed(
+            x_list=x_list,
+            y_list=y_list,
+            x_axe_name="x_axe",
+            y_axe_name="y_axe",
+            legends=legends,
+            title="Title",
+            legend_position="upper right",
+        )
 
     def test_simple_line_graph(self):
-
 
         with self.assertRaises(TypeError):
 
             x1 = np.linspace(0, 10 - 2 * 1, 200) + 1
-            y1 = [1]*len(x1)
+            y1 = [1] * len(x1)
 
-            plot_simple_line_graph(x =x1 ,
-                                        y=y1,
-                                        x_axe_name="x_axe", 
-                                        y_axe_name="y_axe",
-                                        title="Title" )
+            plot_simple_line_graph(
+                x=x1, y=y1, x_axe_name="x_axe", y_axe_name="y_axe", title="Title"
+            )
 
         x1 = np.linspace(0, 10 - 2 * 1, 200) + 1
         y1 = np.sin(x1) + 1.0 + 1
 
-
-        plot_simple_line_graph(x =x1 ,
-                                    y=y1,
-                                    x_axe_name="x_axe", 
-                                    y_axe_name="y_axe",
-                                    title="Title")
-
+        plot_simple_line_graph(
+            x=x1, y=y1, x_axe_name="x_axe", y_axe_name="y_axe", title="Title"
+        )
 
     def test_residues(self):
-        
-        plot_residues(boston['features'],
-                      boston['target'],
-                      boston['regression_pipeline'], 
-                      boston['features_columns'])     
-           
+
+        plot_residues(
+            boston["features"],
+            boston["target"],
+            boston["regression_pipeline"],
+            boston["features_columns"],
+        )
+
     def test_model_coef_weight(self):
-        
-        coef = np.array([-39.29539212, 56.38758691, -7.72501075, 55.14748083, 47.09622402, -224.90523448, -135.84912488, 33.26157851, 85.88832604,
-                         2.82623224, 329.24528965, -90.46706709])
-        columns = np.array(['Length1', 'Length2', 'Length3', 'Height', 'Width', 'Species=Bream',
-                            'Species=Parkki', 'Species=Perch', 'Species=Pike', 'Species=Roach',
-                            'Species=Smelt', 'Species=Whitefish'])
-        
+
+        coef = np.array(
+            [
+                -39.29539212,
+                56.38758691,
+                -7.72501075,
+                55.14748083,
+                47.09622402,
+                -224.90523448,
+                -135.84912488,
+                33.26157851,
+                85.88832604,
+                2.82623224,
+                329.24528965,
+                -90.46706709,
+            ]
+        )
+        columns = np.array(
+            [
+                "Length1",
+                "Length2",
+                "Length3",
+                "Height",
+                "Width",
+                "Species=Bream",
+                "Species=Parkki",
+                "Species=Perch",
+                "Species=Pike",
+                "Species=Roach",
+                "Species=Smelt",
+                "Species=Whitefish",
+            ]
+        )
+
         plot_model_coef_weight(coef, columns)
 
-    def test_shap_classification_summary(self):     
-            
+    def test_shap_classification_summary(self):
+
         with self.assertWarns(expected_warning=Warning):
-                    plot_shap_classification_summary(pipeline=iris['classification_pipeline'],
-                                            X=iris['features'],
-                                            Y=iris['target_encoded'],
-                                            feature_names=iris['features_columns'],
-                                            label_encoder=iris['label_encoder'],
-                                            non_numerical_indexes=np.array([1]))
+            plot_shap_classification_summary(
+                pipeline=iris["classification_pipeline"],
+                X=iris["features"],
+                Y=iris["target_encoded"],
+                feature_names=iris["features_columns"],
+                label_encoder=iris["label_encoder"],
+                non_numerical_indexes=np.array([1]),
+            )
 
-
-
-        plot_shap_classification_summary(pipeline=iris['classification_pipeline'],
-                                            X=iris['features'],
-                                            Y=iris['target_encoded'],
-                                            feature_names=iris['features_columns'],
-                                            label_encoder=iris['label_encoder'],
-                                            non_numerical_indexes=np.array([]))
+        plot_shap_classification_summary(
+            pipeline=iris["classification_pipeline"],
+            X=iris["features"],
+            Y=iris["target_encoded"],
+            feature_names=iris["features_columns"],
+            label_encoder=iris["label_encoder"],
+            non_numerical_indexes=np.array([]),
+        )
 
     def test_draw_bboxes(self):
-        
-        image = np.full((256,256,3), 255).astype(np.uint8)
 
-        bboxes = np.array([[10,10,100,100],[20,20,30,50]])
-        probs = np.array([0.5,0.7])
-        labels = np.array(['Apple', 'Maçã'])
+        image = np.full((256, 256, 3), 255).astype(np.uint8)
 
-        draw_bboxes(image, bboxes, probs = probs, names = labels)
-        draw_bboxes(image, bboxes, probs = None, names = None)
-        draw_bboxes(image, bboxes, probs = None, names = labels)
-        draw_bboxes(image, bboxes, probs = probs, names = None)
+        bboxes = np.array([[10, 10, 100, 100], [20, 20, 30, 50]])
+        probs = np.array([0.5, 0.7])
+        labels = np.array(["Apple", "Maçã"])
+
+        draw_bboxes(image, bboxes, probs=probs, names=labels)
+        draw_bboxes(image, bboxes, probs=None, names=None)
+        draw_bboxes(image, bboxes, probs=None, names=labels)
+        draw_bboxes(image, bboxes, probs=probs, names=None)
 
     def test_plot_bboxes(self):
 
-        image = np.full((256,256,3), 255).astype(np.uint8)
+        image = np.full((256, 256, 3), 255).astype(np.uint8)
 
-        bboxes = np.array([[10,10,100,100],[20,20,30,50]])
-        probs = np.array([0.5,0.7])
-        labels = np.array(['Apple', 'Maçã'])
+        bboxes = np.array([[10, 10, 100, 100], [20, 20, 30, 50]])
+        probs = np.array([0.5, 0.7])
+        labels = np.array(["Apple", "Maçã"])
 
-        plot_bboxes(image, bboxes, probs = probs, names = labels)
-        plot_bboxes(image, bboxes, probs = None, names = None)
-        plot_bboxes(image, bboxes, probs = None, names = labels)
-        plot_bboxes(image, bboxes, probs = probs, names = None)
-
-
+        plot_bboxes(image, bboxes, probs=probs, names=labels)
+        plot_bboxes(image, bboxes, probs=None, names=None)
+        plot_bboxes(image, bboxes, probs=None, names=labels)
+        plot_bboxes(image, bboxes, probs=probs, names=None)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,23 +1,9 @@
 from unittest import TestCase
 from uuid import uuid4
 
-from matplotlib.pyplot import plot
-
 import numpy as np
 import pandas as pd
 
-from category_encoders.ordinal import OrdinalEncoder
-from category_encoders.one_hot import OneHotEncoder
-from sklearn.cluster import KMeans
-from sklearn.compose import ColumnTransformer
-from sklearn.impute import SimpleImputer
-from sklearn.pipeline import Pipeline
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.feature_selection import RFECV
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import LabelEncoder
-from sklearn.linear_model import LinearRegression
-from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import confusion_matrix
 
 from platiagro.plotting import plot_roc_curve
@@ -35,7 +21,6 @@ from platiagro.plotting import plot_clustering_data
 from platiagro.plotting import plot_data_table
 from platiagro.plotting import plot_line_graphs_overlayed
 from platiagro.plotting import plot_line_subgraphs_alongisde
-from platiagro.plotting import plot_simple_line_graph
 from platiagro.plotting import plot_simple_line_graph
 from platiagro.plotting import plot_shap_classification_summary
 from platiagro.plotting import plot_residues

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,6 @@
 import io
 import os
 import requests
-import shutil
-import zipfile
-
 
 import numpy as np
 import pandas as pd

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,9 +19,10 @@ from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import LogisticRegression
 from sklearn.cluster import KMeans
 
+
 def download_zipfile(name):
     if ".zip" in name:
-        name = name.replace(".zip","")
+        name = name.replace(".zip", "")
 
     url = f"https://raw.githubusercontent.com/platiagro/datasets/master/samples/{name}.zip"
     content = requests.get(url).content
@@ -29,13 +30,13 @@ def download_zipfile(name):
     with open(f"tmp/data/{name}.zip", "wb") as code:
         code.write(content)
 
-    
+
 def download_dataset(name):
 
     url = f"https://raw.githubusercontent.com/platiagro/datasets/master/samples/{name}.csv"
     content = requests.get(url).content
-    
-    dataset = pd.read_csv(io.StringIO(content.decode('utf-8')))
+
+    dataset = pd.read_csv(io.StringIO(content.decode("utf-8")))
 
     return dataset
 
@@ -44,7 +45,7 @@ def create_classification_pipeline(X, y):
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.7)
 
-    numerical_indexes  = np.array([0, 1, 2, 3])
+    numerical_indexes = np.array([0, 1, 2, 3])
     non_numerical_indexes = np.array([], int)
     ordinal_indexes_after_handle_missing_values = np.array([], int)
     one_hot_indexes_after_handle_missing_values = np.array([], int)
@@ -55,7 +56,11 @@ def create_classification_pipeline(X, y):
                 "handle_missing_values",
                 ColumnTransformer(
                     [
-                        ("imputer_mean", SimpleImputer(strategy="mean"), numerical_indexes),
+                        (
+                            "imputer_mean",
+                            SimpleImputer(strategy="mean"),
+                            numerical_indexes,
+                        ),
                         (
                             "imputer_mode",
                             SimpleImputer(strategy="most_frequent"),
@@ -103,18 +108,20 @@ def create_classification_pipeline(X, y):
     y_pred = pipeline.predict(X_test)
     y_prob = pipeline.predict_proba(X_test)
 
-    return {'features_train': X_train,
-            'features_test': X_test,
-            'target_train': y_train,
-            'target_test': y_test,
-            'target_predicted': y_pred,
-            'target_probability': y_prob,
-            'classification_pipeline': pipeline}
+    return {
+        "features_train": X_train,
+        "features_test": X_test,
+        "target_train": y_train,
+        "target_test": y_test,
+        "target_predicted": y_pred,
+        "target_probability": y_prob,
+        "classification_pipeline": pipeline,
+    }
 
 
 def create_clustering_pipeline(X):
 
-    numerical_indexes  = np.array([0, 1, 2, 3])
+    numerical_indexes = np.array([0, 1, 2, 3])
     non_numerical_indexes = np.array([], int)
     non_numerical_indexes_after_handle_missing_values = np.array([], int)
 
@@ -124,7 +131,11 @@ def create_clustering_pipeline(X):
                 "handle_missing_values",
                 ColumnTransformer(
                     [
-                        ("imputer_mean", SimpleImputer(strategy="mean"), numerical_indexes),
+                        (
+                            "imputer_mean",
+                            SimpleImputer(strategy="mean"),
+                            numerical_indexes,
+                        ),
                         (
                             "imputer_mode",
                             SimpleImputer(strategy="most_frequent"),
@@ -149,11 +160,7 @@ def create_clustering_pipeline(X):
             ),
             (
                 "estimator",
-                KMeans(
-                    n_clusters=3,
-                    n_init=10,
-                    max_iter=300
-                ),
+                KMeans(n_clusters=3, n_init=10, max_iter=300),
             ),
         ]
     )
@@ -162,15 +169,14 @@ def create_clustering_pipeline(X):
 
     clusters = pipeline.named_steps.estimator.labels_
 
-    return {'clusters': clusters,
-            'clustering_pipeline': pipeline}
+    return {"clusters": clusters, "clustering_pipeline": pipeline}
 
 
 def create_regression_pipeline(X, y):
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.7)
 
-    numerical_indexes =  np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+    numerical_indexes = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
     non_numerical_indexes = np.array([], int)
     one_hot_indexes_after_handle_missing_values = np.array([], int)
     ordinal_indexes_after_handle_missing_values = np.array([], int)
@@ -181,7 +187,11 @@ def create_regression_pipeline(X, y):
                 "handle_missing_values",
                 ColumnTransformer(
                     [
-                        ("imputer_mean", SimpleImputer(strategy="mean"), numerical_indexes),
+                        (
+                            "imputer_mean",
+                            SimpleImputer(strategy="mean"),
+                            numerical_indexes,
+                        ),
                         (
                             "imputer_mode",
                             SimpleImputer(strategy="most_frequent"),
@@ -217,58 +227,62 @@ def create_regression_pipeline(X, y):
 
     y_pred = pipeline.predict(X_test)
 
-    return {'features_train': X_train,
-            'features_test': X_test,
-            'target_train': y_train,
-            'target_test': y_test,
-            'target_predicted': y_pred,
-            'regression_pipeline': pipeline}
+    return {
+        "features_train": X_train,
+        "features_test": X_test,
+        "target_train": y_train,
+        "target_test": y_test,
+        "target_predicted": y_pred,
+        "regression_pipeline": pipeline,
+    }
 
 
 def get_iris():
 
     # Default dataset
-    dataset = download_dataset('iris')
+    dataset = download_dataset("iris")
 
     # Dataset separated from target
     X = dataset.copy()
-    y = np.array(X.pop('Species'))
+    y = np.array(X.pop("Species"))
 
     # Encode target
     label_encoder = LabelEncoder()
     y_enc = label_encoder.fit_transform(y)
 
-    data = {'dataset': dataset,
-            'dataset_columns': dataset.columns,
-            'features': X,
-            'target': y,
-            'features_columns': X.columns,
-            'label_encoder':label_encoder,
-            'target_encoded': y_enc}
+    data = {
+        "dataset": dataset,
+        "dataset_columns": dataset.columns,
+        "features": X,
+        "target": y,
+        "features_columns": X.columns,
+        "label_encoder": label_encoder,
+        "target_encoded": y_enc,
+    }
 
     # Create and fit pipelines
     classification_pipeline = create_classification_pipeline(X, y_enc)
     clustering_pipeline = create_clustering_pipeline(X)
 
-    
     return {**data, **classification_pipeline, **clustering_pipeline}
-
 
 
 def get_boston():
 
     # Default dataset
-    dataset = download_dataset('boston')
+    dataset = download_dataset("boston")
 
     # Dataset separated from target
     X = dataset.copy()
-    y = np.array(X.pop('medv'))
+    y = np.array(X.pop("medv"))
 
-    data = {'dataset': dataset,
-            'dataset_columns': dataset.columns,
-            'features': X,
-            'target': y,
-            'features_columns': X.columns}
+    data = {
+        "dataset": dataset,
+        "dataset_columns": dataset.columns,
+        "features": X,
+        "target": y,
+        "features_columns": X.columns,
+    }
 
     # Create and fit pipeline
     regression_pipeline = create_regression_pipeline(X, y)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+import io
+from typing import Any
+
+from minio.error import S3Error
+from minio.helpers import ObjectWriteResult
+from urllib3.response import HTTPResponse
+
+CSV_DATA = (
+    "SepalLengthCm,SepalWidthCm,PetalLengthCm,PetalWidthCm,Species\n"
+    "5.1,3.5,1.4,0.2,Iris-setosa\n"
+    "4.9,3.0,1.4,0.2,Iris-setosa\n"
+    "4.7,3.2,1.3,0.2,Iris-setosa\n"
+    "4.6,3.1,1.5,0.2,Iris-setosa\n"
+).encode()
+BINARY_DATA = b"\x89PNG\r\n"
+
+NO_SUCH_KEY_ERROR = S3Error(
+    code="NoSuchKey",
+    message="",
+    resource=None,
+    request_id=None,
+    host_id=None,
+    response=None,
+)
+
+
+def get_object_side_effect(bucket_name: str, object_name: str, **kwargs):
+    """
+    Returns a mock object when accessing bucket objects.
+
+    Parameters
+    ----------
+    bucket_name : str
+    object_name : str
+    **kwargs
+
+    Returns
+    -------
+    HTTPResponse
+    """
+    if object_name.endswith(".metadata"):
+        filename = object_name[: -len(".metadata")].split("/")[-1]
+        body = f'{{"filename": "{filename}"}}'.encode()
+    elif object_name.endswith(".csv"):
+        body = CSV_DATA
+    else:
+        body = BINARY_DATA
+
+    return HTTPResponse(body=io.BytesIO(body), preload_content=False)
+
+
+def put_object_side_effect(
+    bucket_name: str, object_name: str, data: Any, length: int, **kwargs
+):
+    """
+    Returns a mock object when adding objects to bucket.
+
+    Parameters
+    ----------
+    bucket_name : str
+    object_name : str
+    data : Any
+    length : int
+    **kwargs
+
+    Returns
+    -------
+    ObjectWriteResult
+    """
+    return ObjectWriteResult(
+        bucket_name=bucket_name,
+        object_name=object_name,
+        version_id=0,
+        etag="",
+        http_headers={},
+    )
+
+
+def fput_object_side_effect(
+    bucket_name: str, object_name: str, file_path: str, **kwargs
+):
+    """
+    Returns a mock object when adding objects to bucket.
+
+    Parameters
+    ----------
+    bucket_name : str
+    object_name : str
+    file_path : str
+    **kwargs
+
+    Returns
+    -------
+    ObjectWriteResult
+    """
+    return ObjectWriteResult(
+        bucket_name=bucket_name,
+        object_name=object_name,
+        version_id=0,
+        etag="",
+        http_headers={},
+    )

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,6 +2,7 @@
 import base64
 import io
 import joblib
+import json
 import os
 from typing import Any
 
@@ -66,6 +67,8 @@ def get_object_side_effect(bucket_name: str, object_name: str, **kwargs):
         body = f'{{"filename": "{filename}"}}'.encode()
     elif object_name.endswith(".csv"):
         body = CSV_DATA
+    elif object_name.endswith("metrics.json"):
+        body = json.dumps([{"accuracy": 1.0}]).encode()
     elif object_name.endswith("model.joblib"):
         buffer = io.BytesIO()
         joblib.dump({"model": MODEL}, buffer)

--- a/tests/util.py
+++ b/tests/util.py
@@ -10,6 +10,8 @@ from minio.error import S3Error
 from minio.helpers import ObjectWriteResult
 from urllib3.response import HTTPResponse
 
+CSV_DATASET_NAME = "unk.csv"
+
 CSV_DATA = (
     "SepalLengthCm,SepalWidthCm,PetalLengthCm,PetalWidthCm,Species\n"
     "5.1,3.5,1.4,0.2,Iris-setosa\n"
@@ -17,6 +19,8 @@ CSV_DATA = (
     "4.7,3.2,1.3,0.2,Iris-setosa\n"
     "4.6,3.1,1.5,0.2,Iris-setosa\n"
 ).encode()
+
+BINARY_DATASET_NAME = "unk.zip"
 
 BINARY_DATA = b"\x89PNG\r\n"
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -29,6 +29,15 @@ NO_SUCH_KEY_ERROR = S3Error(
     response=None,
 )
 
+BUCKET_ALREADY_OWNED_BY_YOU = S3Error(
+    code="BucketAlreadyOwnedByYou",
+    message="",
+    resource=None,
+    request_id=None,
+    host_id=None,
+    response=None,
+)
+
 FIGURE_SVG = (
     "<svg viewBox='0 0 125 80' xmlns='http://www.w3.org/2000/svg'>\n"
     '<text y="75" font-size="100" font-family="serif"><![CDATA[10]]></text>\n'

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import base64
 import io
 from typing import Any
 
@@ -13,6 +14,7 @@ CSV_DATA = (
     "4.7,3.2,1.3,0.2,Iris-setosa\n"
     "4.6,3.1,1.5,0.2,Iris-setosa\n"
 ).encode()
+
 BINARY_DATA = b"\x89PNG\r\n"
 
 NO_SUCH_KEY_ERROR = S3Error(
@@ -23,6 +25,16 @@ NO_SUCH_KEY_ERROR = S3Error(
     host_id=None,
     response=None,
 )
+
+FIGURE_SVG = (
+    "<svg viewBox='0 0 125 80' xmlns='http://www.w3.org/2000/svg'>\n"
+    '<text y="75" font-size="100" font-family="serif"><![CDATA[10]]></text>\n'
+    "</svg>\n"
+)
+FIGURE_SVG_BASE64 = base64.b64encode(FIGURE_SVG.encode()).decode()
+
+FIGURE_HTML = "<html><body>HELLO!</body></html>"
+FIGURE_HTML_BASE64 = base64.b64encode(FIGURE_HTML.encode()).decode()
 
 
 def get_object_side_effect(bucket_name: str, object_name: str, **kwargs):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import base64
 import io
+import joblib
+import os
 from typing import Any
 
 from minio.error import S3Error
@@ -37,6 +39,14 @@ FIGURE_HTML = "<html><body>HELLO!</body></html>"
 FIGURE_HTML_BASE64 = base64.b64encode(FIGURE_HTML.encode()).decode()
 
 
+class MockModel:
+    def predict(self, x):
+        return True
+
+
+MODEL = MockModel()
+
+
 def get_object_side_effect(bucket_name: str, object_name: str, **kwargs):
     """
     Returns a mock object when accessing bucket objects.
@@ -56,6 +66,11 @@ def get_object_side_effect(bucket_name: str, object_name: str, **kwargs):
         body = f'{{"filename": "{filename}"}}'.encode()
     elif object_name.endswith(".csv"):
         body = CSV_DATA
+    elif object_name.endswith("model.joblib"):
+        buffer = io.BytesIO()
+        joblib.dump({"model": MODEL}, buffer)
+        buffer.seek(0, os.SEEK_SET)
+        body = buffer.read()
     else:
         body = BINARY_DATA
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -76,7 +76,7 @@ def get_object_side_effect(bucket_name: str, object_name: str, **kwargs):
     HTTPResponse
     """
     if object_name.endswith(".metadata"):
-        filename = object_name[: -len(".metadata")].split("/")[-1]
+        filename = object_name.split("/")[1]
         body = f'{{"filename": "{filename}"}}'.encode()
     elif object_name.endswith(".csv"):
         body = CSV_DATA


### PR DESCRIPTION
Refactors test_artifacts.py …
patches MINIO_CLIENT method fget_object so MinIO server isn't called


Replaces occurrences of dict["key"] by get("key") …
And formats datasets.py using black


Refactors test_datasets.py …
patches MINIO_CLIENT methods so MinIO server isn't called


Replaces duplicate S3Error instance by a const


Refactors test_featuretypes.py …
Adds docstrings to tests.


Formats util.py using black


Refactors test_figures.py …
patches MINIO_CLIENT methods so MinIO server isn't called


Removes unused imports from test_datasets.py


Adds missing docstrings to tests/


Formats platiagro/io.py using black …
Also adds missing docstring.


Refactors test_io.py …
Adds docstrings and formats file using black.


Refactors tests/client/*.py …
Adds docstrings and formats files using black.


Refactors test_models.py …
patches MINIO_CLIENT methods so MinIO server isn't called


Refactors test_metrics.py …

patches MINIO_CLIENT methods so MinIO server isn't called
Fabio Beranizo
Refactors tests/test_pipeline.py …
4bb12a0
Adds docstrings and formats files using black.
Fabio Beranizo
Formats tests/test_plotting.py and test_metrics_nlp.py using black
e74cd50
Fabio Beranizo
Removes MinIO from ci.yaml …
e249e10
Since unit tests no longer depend on MinIO, we can remove this step
and make CI faster. :)